### PR TITLE
Fix for g2136203 and cobertura model coverage

### DIFF
--- a/src/main/java/com/mathworks/ci/MatlabBuilder.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilder.java
@@ -617,14 +617,12 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
     
     // Concatenate the input arguments
     private String getInputArguments() {
-        MatlabBuilderConstants constants = new MatlabBuilderConstants();
-        
-    	String pdfReport = constants.PDF_REPORT + "," + getTestRunTypeList().getBooleanByName("taPDFReportChkBx");
-    	String tapResults = constants.TAP_RESULTS + "," + getTestRunTypeList().getBooleanByName("tatapChkBx");
-    	String junitResults = constants.JUNIT_RESULTS + "," + getTestRunTypeList().getBooleanByName("taJunitChkBx");
-    	String stmResults = constants.STM_RESULTS + "," + getTestRunTypeList().getBooleanByName("taSTMResultsChkBx");
-    	String coberturaCodeCoverage = constants.COBERTURA_CODE_COVERAGE + "," + getTestRunTypeList().getBooleanByName("taCoberturaChkBx");
-    	String coberturaModelCoverage = constants.COBERTURA_MODEL_COVERAGE + "," + getTestRunTypeList().getBooleanByName("taModelCoverageChkBx");
+    	String pdfReport = MatlabBuilderConstants.PDF_REPORT + "," + getTestRunTypeList().getBooleanByName("taPDFReportChkBx");
+    	String tapResults = MatlabBuilderConstants.TAP_RESULTS + "," + getTestRunTypeList().getBooleanByName("tatapChkBx");
+    	String junitResults = MatlabBuilderConstants.JUNIT_RESULTS + "," + getTestRunTypeList().getBooleanByName("taJunitChkBx");
+    	String stmResults = MatlabBuilderConstants.STM_RESULTS + "," + getTestRunTypeList().getBooleanByName("taSTMResultsChkBx");
+    	String coberturaCodeCoverage = MatlabBuilderConstants.COBERTURA_CODE_COVERAGE + "," + getTestRunTypeList().getBooleanByName("taCoberturaChkBx");
+    	String coberturaModelCoverage = MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE + "," + getTestRunTypeList().getBooleanByName("taModelCoverageChkBx");
         
     	String inputArgsToMatlabFcn = pdfReport + "," + tapResults + "," + junitResults + ","
     			+ stmResults + "," + coberturaCodeCoverage + "," + coberturaModelCoverage;

--- a/src/main/java/com/mathworks/ci/MatlabBuilder.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilder.java
@@ -585,7 +585,7 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
             String matlabFunctionName =
                     FilenameUtils.removeExtension(Message.getValue(MatlabBuilderConstants.MATLAB_RUNNER_TARGET_FILE));
             runCommand = "try,exit(" + matlabFunctionName + "("
-                    + getInputArguments() + ","
+                    + getInputArguments()
                     + ")),catch e,disp(getReport(e,'extended')),exit(1),end";
         } else {
             runCommand = "try,eval(\"" + getCustomMatlabCommand().replaceAll("\"","\"\"")

--- a/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
@@ -7,7 +7,7 @@ public class MatlabBuilderConstants {
     static final double BASE_MATLAB_VERSION_RUNTESTS_SUPPORT = 8.1;
     static final double BASE_MATLAB_VERSION_BATCH_SUPPORT = 9.5;
     static final double BASE_MATLAB_VERSION_COBERTURA_SUPPORT = 9.3;
-    static final double BASE_MATLAB_VERSION_MODELCOVERAGE_SUPPORT = 9.4;
+    static final double BASE_MATLAB_VERSION_MODELCOVERAGE_SUPPORT = 9.5;
     static final double BASE_MATLAB_VERSION_EXPORTSTMRESULTS_SUPPORT = 9.6;
     
     static final String MATLAB_RUNNER_TARGET_FILE = "Builder.matlab.runner.target.file.name";

--- a/src/main/resources/com/mathworks/ci/MatlabBuilder/RunTestsAutomaticallyOption/help-taModelCoverageChkBx.html
+++ b/src/main/resources/com/mathworks/ci/MatlabBuilder/RunTestsAutomaticallyOption/help-taModelCoverageChkBx.html
@@ -1,6 +1,6 @@
 <div>
 <br>Generate a Cobertura model coverage report, <b>coberturamodelcoverage.xml</b>, and save it in the <b>matlabTestArtifacts</b> folder of the Jenkins workspace.
 This report includes coverage results for Simulink&#174; models that are tested using Simulink Test&#8482;.<br>
-<br>Note: This feature requires a <b>Simulink Coverage&#8482;</b> license and is supported only in MATLAB R2018a or a newer release.<br>
+<br>Note: This feature requires a <b>Simulink Coverage&#8482;</b> license and is supported only in MATLAB R2018b or a newer release.<br>
 <br>
 </div>

--- a/src/main/resources/com/mathworks/ci/MatlabBuilder/runMatlabTests.m
+++ b/src/main/resources/com/mathworks/ci/MatlabBuilder/runMatlabTests.m
@@ -90,7 +90,7 @@ if produceModelCoverage
         warning('MATLAB:testArtifact:cannotGenerateModelCoverageReport', ...
                 'Unable to generate Cobertura model coverage report. To generate the report, use a Simulink Coverage license with MATLAB R2018a or a newer release.');
     else 
-        import sltest.plugins.ModelCoveragePlugin;
+        import('sltest.plugins.ModelCoveragePlugin');
         
         mkdirIfNeeded(resultsDir);
         coverageFile = fullfile(resultsDir, 'coberturamodelcoverage.xml');
@@ -117,7 +117,7 @@ if producePDFReport
         issuePDFReportUnsupportedWarning;
     else
         mkdirIfNeeded(resultsDir);
-        import matlab.unittest.plugins.TestReportPlugin;
+        import('matlab.unittest.plugins.TestReportPlugin');
         runner.addPlugin(TestReportPlugin.producingPDF(getPDFFilePath(resultsDir)));
         
         if ~stmResultsPluginAddedToRunner && stmResultsPluginPresent

--- a/src/main/resources/com/mathworks/ci/MatlabBuilder/runMatlabTests.m
+++ b/src/main/resources/com/mathworks/ci/MatlabBuilder/runMatlabTests.m
@@ -84,11 +84,11 @@ if produceCobertura
     end
 end
 
-% Produce Cobertura model coverage report (Not supported below R2018a) 
+% Produce Cobertura model coverage report (Not supported below R2018b) 
 if produceModelCoverage
-    if ~exist('sltest.plugins.ModelCoveragePlugin', 'class')
+    if ~exist('sltest.plugins.ModelCoveragePlugin', 'class') || ~coberturaModelCoverageSupported
         warning('MATLAB:testArtifact:cannotGenerateModelCoverageReport', ...
-                'Unable to generate Cobertura model coverage report. To generate the report, use a Simulink Coverage license with MATLAB R2018a or a newer release.');
+                'Unable to generate Cobertura model coverage report. To generate the report, use a Simulink Coverage license with MATLAB R2018b or a newer release.');
     else 
         import('sltest.plugins.ModelCoveragePlugin');
         
@@ -170,6 +170,11 @@ tf = ~verLessThan('matlab',BASE_VERSION_REPORTPLUGIN_SUPPORT);
 
 function tf = stmResultsPluginPresent
 tf = logical(exist('sltest.plugins.TestManagerResultsPlugin', 'class'));
+
+function tf = coberturaModelCoverageSupported
+BASE_VERSION_MODELCOVERAGE_SUPPORT = '9.5'; % R2018b
+
+tf = ~verLessThan('matlab',BASE_VERSION_MODELCOVERAGE_SUPPORT);
 
 function tf = exportSTMResultsSupported
 BASE_VERSION_EXPORTSTMRESULTS_SUPPORT = '9.6'; % R2019a

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -10,6 +10,6 @@ Builder.matlab.test.support.error = To run tests with the Jenkins plugin, use MA
 builder.matlab.automatictestoption.display.name = Automatic
 builder.matlab.customcommandoption.display.name = Custom
 Releaseinfo.matlab.version.not.found.error = Error finding MATLAB release for given MATLAB root. Verify MATLAB root path.
-Builder.matlab.modelcoverage.support.warning = To generate a Cobertura model coverage report, use MATLAB R2018a or a newer release.
+Builder.matlab.modelcoverage.support.warning = To generate a Cobertura model coverage report, use MATLAB R2018b or a newer release.
 Builder.matlab.exportstmresults.support.warning = To export Simulink Test Manager results, use MATLAB R2019a or a newer release.
 

--- a/src/test/java/com/mathworks/ci/MatlabBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/MatlabBuilderTest.java
@@ -427,7 +427,7 @@ public class MatlabBuilderTest {
     @Test
     public void verifyModelCoverageWarning() throws Exception {
         project.getBuildersList().add(this.matlabBuilder);
-        this.matlabBuilder.setMatlabRoot(getMatlabroot("R2017a"));
+        this.matlabBuilder.setMatlabRoot(getMatlabroot("R2018a"));
         HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
         HtmlCheckBoxInput modelCoverageChkBx = page.getElementByName("taModelCoverageChkBx");
         modelCoverageChkBx.setChecked(true);

--- a/src/test/resources/testconfig.properties
+++ b/src/test/resources/testconfig.properties
@@ -6,5 +6,5 @@ Verify.build.ignore.test.failure = Build Ignored test failure
 Builder.matlab.cobertura.support.warning = To generate a Cobertura code coverage report, use MATLAB R2017b or a newer release.
 Builder.invalid.matlab.root.warning = Unable to find MATLAB from the specified location on this system(but perhaps it exists on some agents)
 Builder.matlab.root.empty.error = Full path to the MATLAB root folder is required.
-Builder.matlab.modelcoverage.support.warning = To generate a Cobertura model coverage report, use MATLAB R2018a or a newer release.
+Builder.matlab.modelcoverage.support.warning = To generate a Cobertura model coverage report, use MATLAB R2018b or a newer release.
 Builder.matlab.exportstmresults.support.warning = To export Simulink Test Manager results, use MATLAB R2019a or a newer release.

--- a/src/test/resources/versioninfo/R2018a/VersionInfo.xml
+++ b/src/test/resources/versioninfo/R2018a/VersionInfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Version information for MathWorks R2018a Release -->
+<MathWorks_version_info>
+  <version>9.4.0.813654</version>
+  <release>R2018a</release>
+  <description></description>
+  <date>Feb 23 2018</date>
+  <checksum>4291774302</checksum>
+</MathWorks_version_info>


### PR DESCRIPTION
Two fixes here:
1) There was an incorrect syntax in runMatlabTests call for versions below R2018b - [g2136203](http://komodo.mathworks.com/main/gecko/view?Record=2136203)

2) Cobertura model coverage is not supported in R2018a. It is only supported from R2018b onwards.
