### PR TITLE
Removed PDF test report option from plugin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Jenkins MATLAB Plugin
 
-The Jenkins plugin for MATLAB&reg; enables you to easily run your MATLAB and Simulink&reg; tests and generate artifacts such as *PDF* test report, *JUnit* and *TAP* test results, and *Cobertura* code or model coverage reports. You can also export your Simulink Test&#8482; Manager results. This guide shows you examples of how to configure the plugin for different objectives, considering a Microsoft&reg; Windows&reg; platform.
+The Jenkins plugin for MATLAB&reg; enables you to easily run your MATLAB and Simulink&reg; tests and generate artifacts such as *JUnit* and *TAP* test results, and *Cobertura* code or model coverage reports. You can also export your Simulink Test&#8482; Manager results. This guide shows you examples of how to configure the plugin for different objectives, considering a Microsoft&reg; Windows&reg; platform.
 
 ## Configure Plugin for Freestyle Project
 To configure the plugin for a freestyle project, select **Run MATLAB Tests** from the **Add build step** list. Then, enter the value returned by the **matlabroot** function in the **MATLAB root** field.
 
   ![new_add_build_step](https://user-images.githubusercontent.com/47204011/55624172-be54a100-57c2-11e9-9596-52d3a60ee467.png)
   
-  ![new_enter_matlabroot](https://user-images.githubusercontent.com/51316279/67834674-085df500-fb0e-11e9-927b-c4da6bff0ed6.png)
+  ![new_enter_matlabroot](https://user-images.githubusercontent.com/51316279/70772996-28830400-1d9c-11ea-92d1-db9f054c304c.png)
   
 ### Option 1: Freestyle Project with Automatic Test Mode
 With the Jenkins plugin for MATLAB, you have the option to run your tests in either *automatic* or *custom* mode. The automatic test mode employs a default setting to run tests written using the MATLAB Unit Testing Framework and/or Simulink Test. If your source code is organized as files and folders within a project, the plugin will consider any test files in the project that have been tagged as **Test**. If your code does not leverage a project or uses a MATLAB version prior to R2019a, the plugin will consider all tests in the current Jenkins workspace including the subfolders. 
@@ -18,17 +18,17 @@ The automatic test execution feature of the plugin enables you to generate diffe
 
 1) From the **Test mode** drop-down list, select the **Automatic** option (**Automatic** is the default testing mode).
   
-  ![new_select_automatic_option](https://user-images.githubusercontent.com/51316279/67842305-e7060480-fb1f-11e9-8f20-d2299636be02.png)
+  ![new_select_automatic_option](https://user-images.githubusercontent.com/51316279/70773784-6719be00-1d9e-11ea-9a6c-7b277d63e10a.png)
   
 2) Select your desired test artifacts.
 
-  ![new_select_all_test_artifacts](https://user-images.githubusercontent.com/51316279/67841415-056b0080-fb1e-11e9-928f-8285b7f2fc71.png)
+  ![new_select_all_test_artifacts](https://user-images.githubusercontent.com/51316279/70773293-0dfd5a80-1d9d-11ea-8d24-28407e67c8a5.png)
 
   The selected artifacts will be saved in the **matlabTestArtifacts** folder of the Jenkins workspace.
 
   ![Workspace01](https://user-images.githubusercontent.com/47204011/55470859-1e621080-5626-11e9-98f2-044144272643.JPG)
   
-  ![Test_artifacts](https://user-images.githubusercontent.com/51316279/67843000-33057900-fb21-11e9-9ce2-870ecf5ffdd0.png)
+  ![Test_artifacts](https://user-images.githubusercontent.com/51316279/70776181-5bc89180-1da2-11ea-92e6-4c71deab7199.png)
   
   If you do not select any of the test artifact check boxes, the **matlabTestArtifacts** folder will not be created in the workspace. However, tests will still run and potential test failures will fail the build. 
 
@@ -41,7 +41,7 @@ This option enables you to develop your custom MATLAB commands for running tests
 
 1) From the **Test mode** drop-down list, select the **Custom** option.
 
-  ![new_select_custom](https://user-images.githubusercontent.com/51316279/67842071-79f26f00-fb1f-11e9-8d46-274ffa941cfd.png)
+  ![new_select_custom](https://user-images.githubusercontent.com/51316279/70775386-42731580-1da1-11ea-9523-41c83443ee5b.png)
 
 2) Enter your commands in the **MATLAB command** field. If you specify more than one MATLAB command, use a comma or semicolon to separate the commands. The build will fail if the execution of any command results in an error.
 
@@ -68,7 +68,7 @@ To configure the plugin for a matrix build where tests run automatically in mult
 
 2) In the **Run MATLAB Tests** section of the project, include the user-defined axis name in the **MATLAB root** field to specify the locations where MATLAB is installed. In this example, **$VERSION** will be replaced by one axis value per build step.
 
-![image](https://user-images.githubusercontent.com/51316279/67841685-a659bb80-fb1e-11e9-802a-3b357933f9c7.png)
+![image](https://user-images.githubusercontent.com/51316279/70773424-72b8b500-1d9d-11ea-97ca-807ecd6c4e47.png)
 
 You can select the test artifact check boxes when tests run automatically. Once you have made your selections, save your settings and run the build.
 
@@ -86,7 +86,7 @@ To configure the matrix build where you can customize the MATLAB test execution,
 
 3) In the **Run MATLAB Tests** section of the project, use the **VERSION** axis to specify the locations where MATLAB is installed.
 
-![image](https://user-images.githubusercontent.com/51316279/67841685-a659bb80-fb1e-11e9-802a-3b357933f9c7.png)
+![image](https://user-images.githubusercontent.com/51316279/70773424-72b8b500-1d9d-11ea-97ca-807ecd6c4e47.png)
 
 4) From the **Test mode** drop-down list, select the **Custom** option. Use the second user-defined axis to create your commands and enter them in the **MATLAB command** field. Then, save your settings and run the build. 
 

--- a/src/main/java/com/mathworks/ci/MatlabBuilder.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilder.java
@@ -343,7 +343,6 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
         private boolean tatapChkBx;
         private boolean taJunitChkBx;
         private boolean taCoberturaChkBx;
-        private boolean taPDFReportChkBx;
         private boolean taSTMResultsChkBx;
         private boolean taModelCoverageChkBx;
 
@@ -368,11 +367,6 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
         }
         
         @DataBoundSetter
-        public void setTaPDFReportChkBx(boolean taPDFReportChkBx) {
-            this.taPDFReportChkBx = taPDFReportChkBx;
-        }
-        
-        @DataBoundSetter
         public void setTaSTMResultsChkBx(boolean taSTMResultsChkBx) {
             this.taSTMResultsChkBx = taSTMResultsChkBx;
         }
@@ -392,10 +386,6 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
 
         public boolean getTaCoberturaChkBx() {
             return taCoberturaChkBx;
-        }
-                
-        public boolean getTaPDFReportChkBx() {
-            return taPDFReportChkBx;
         }
 
         public boolean getTaSTMResultsChkBx() {
@@ -423,8 +413,6 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
                     return this.getTaJunitChkBx();
                 case "taCoberturaChkBx":
                     return this.getTaCoberturaChkBx();
-                case "taPDFReportChkBx":
-                    return this.getTaPDFReportChkBx();
                 case "taSTMResultsChkBx":
                     return this.getTaSTMResultsChkBx();
                 case "taModelCoverageChkBx":
@@ -617,14 +605,13 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
     
     // Concatenate the input arguments
     private String getInputArguments() {
-    	String pdfReport = MatlabBuilderConstants.PDF_REPORT + "," + getTestRunTypeList().getBooleanByName("taPDFReportChkBx");
     	String tapResults = MatlabBuilderConstants.TAP_RESULTS + "," + getTestRunTypeList().getBooleanByName("tatapChkBx");
     	String junitResults = MatlabBuilderConstants.JUNIT_RESULTS + "," + getTestRunTypeList().getBooleanByName("taJunitChkBx");
     	String stmResults = MatlabBuilderConstants.STM_RESULTS + "," + getTestRunTypeList().getBooleanByName("taSTMResultsChkBx");
     	String coberturaCodeCoverage = MatlabBuilderConstants.COBERTURA_CODE_COVERAGE + "," + getTestRunTypeList().getBooleanByName("taCoberturaChkBx");
     	String coberturaModelCoverage = MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE + "," + getTestRunTypeList().getBooleanByName("taModelCoverageChkBx");
         
-    	String inputArgsToMatlabFcn = pdfReport + "," + tapResults + "," + junitResults + ","
+    	String inputArgsToMatlabFcn = tapResults + "," + junitResults + ","
     			+ stmResults + "," + coberturaCodeCoverage + "," + coberturaModelCoverage;
         
         return inputArgsToMatlabFcn;

--- a/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
@@ -15,7 +15,6 @@ public class MatlabBuilderConstants {
     static final String AUTOMATIC_OPTION = "RunTestsAutomaticallyOption";
     
     // Input parameter names (Passed to runMatlabTests.m as name-value pair arguments)
-    static final String PDF_REPORT = "'PDFReport'";
     static final String TAP_RESULTS = "'TAPResults'";
     static final String JUNIT_RESULTS = "'JUnitResults'";
     static final String STM_RESULTS = "'SimulinkTestResults'";

--- a/src/main/resources/com/mathworks/ci/MatlabBuilder/RunTestsAutomaticallyOption/config.jelly
+++ b/src/main/resources/com/mathworks/ci/MatlabBuilder/RunTestsAutomaticallyOption/config.jelly
@@ -2,10 +2,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     
 <f:section title="Generate Test Artifacts">
-  	 <f:entry field="taPDFReportChkBx">
-    	<f:checkbox title="PDF test report " name="taPDFReportChkBx" checked="${instance.taPDFReportChkBx}"/>
-     </f:entry>
- 
 	 <f:entry field="tatapChkBx">
     	<f:checkbox title="TAP test results" name="tatapChkBx" checked="${instance.tatapChkBx}"/>
      </f:entry>

--- a/src/test/java/com/mathworks/ci/MatlabBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/MatlabBuilderTest.java
@@ -300,7 +300,7 @@ public class MatlabBuilderTest {
         this.matlabBuilder.setMatlabRoot(getMatlabroot("R2018b"));
         FreeStyleBuild build = getBuildforRunTestAutomatically();
         jenkins.assertLogContains("-batch", build);
-        jenkins.assertLogContains("\'PDFReport\',true,\'TAPResults\',true," +
+        jenkins.assertLogContains("\'TAPResults\',true," +
                                   "\'JUnitResults\',true,\'SimulinkTestResults\',true," +
                                   "\'CoberturaCodeCoverage\',true,\'CoberturaModelCoverage\',true", build);
     }
@@ -547,7 +547,6 @@ public class MatlabBuilderTest {
         runOption.setTaJunitChkBx(true);
         runOption.setTatapChkBx(true);
         runOption.setTaModelCoverageChkBx(true);
-        runOption.setTaPDFReportChkBx(true);
         runOption.setTaSTMResultsChkBx(true);
         this.matlabBuilder.setTestRunTypeList(runOption);
         project.getBuildersList().add(this.matlabBuilder);


### PR DESCRIPTION
- "PDF test report" option throws errors when running on MAC platform. Refer https://github.com/mathworks/jenkins-matlab-plugin/issues/48 for details on the issue.

- Because of the issue, I am removing the PDF test report option from UI so that we don't hold the release. We can add the PDF option once the issue is resolved.

Note: I didn't remove the business logic for PDF test report feature from runMatlabTests.m script.

The UI now looks like this:
![image](https://user-images.githubusercontent.com/51316279/70710583-7ef13380-1d05-11ea-8e04-777bc3de1b83.png)