### PR TITLE
Fix for matrix issue 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,15 @@
 	  <tag>HEAD</tag>
   </scm>
 
+	<dependencies>
+		<!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins/matrix-project -->
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>matrix-project</artifactId>
+			<version>1.14</version>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<!-- Plugin to download the matlab run scripts and keep it under class 

--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -33,7 +33,7 @@ public interface MatlabBuild {
             TaskListener listener, EnvVars envVars, String matlabCommand, String uniqueName)
             throws IOException, InterruptedException {
         // Get node specific tmp directory to copy matlab runner script
-        String tmpDir = getNodeSpecificTmpFolderPath();
+        String tmpDir = getNodeSpecificTmpFolderPath(workspace);
         FilePath targetWorkspace = new FilePath(launcher.getChannel(), tmpDir);
         ProcStarter matlabLauncher;
         if (launcher.isUnix()) {
@@ -70,9 +70,12 @@ public interface MatlabBuild {
         targetFilePath.chmod(0755);
     }
 
-    default FilePath getFilePathForUniqueFolder(Launcher launcher, String uniqueName)
+    default FilePath getFilePathForUniqueFolder(Launcher launcher, String uniqueName,FilePath workspace)
             throws IOException, InterruptedException {
-        Computer cmp = Computer.currentComputer();
+        /*Use of Computer is not recommended as jenkins hygeine for pipeline support
+         * https://javadoc.jenkins-ci.org/jenkins/tasks/SimpleBuildStep.html */
+        
+        Computer cmp = workspace.toComputer();
         String tmpDir = (String) cmp.getSystemProperties().get("java.io.tmpdir");
         if (launcher.isUnix()) {
             tmpDir = tmpDir + "/" + uniqueName;
@@ -82,8 +85,8 @@ public interface MatlabBuild {
         return new FilePath(launcher.getChannel(), tmpDir);
     }
 
-    default String getNodeSpecificTmpFolderPath() throws IOException, InterruptedException {
-        Computer cmp = Computer.currentComputer();
+    default String getNodeSpecificTmpFolderPath(FilePath workspace) throws IOException, InterruptedException {
+        Computer cmp = workspace.toComputer();
         String tmpDir = (String) cmp.getSystemProperties().get("java.io.tmpdir");
         return tmpDir;
     }

--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -2,15 +2,13 @@ package com.mathworks.ci;
 /**
  * Copyright 2019-2020 The MathWorks, Inc.
  * 
- * Build Interface has two default methods. MATLAB builders can override the 
- * default behavior.
+ * Build Interface has two default methods. MATLAB builders can override the default behavior.
  * 
  */
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
-
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -19,34 +17,42 @@ import hudson.model.Computer;
 import hudson.model.TaskListener;
 
 public interface MatlabBuild {
-    
+
     /**
-     * This Method decorates the launcher with MATLAB command provided and returns the Process 
+     * This Method decorates the launcher with MATLAB command provided and returns the Process
      * object to launch MATLAB with appropriate startup options like -r or -batch
-     * @param workspace Current build workspace 
+     * 
+     * @param workspace Current build workspace
      * @param launcher Current build launcher
-     * @param listener Current build listener 
+     * @param listener Current build listener
      * @param envVars Environment variables of the current build
-     * @param matlabCommand MATLAB command to execute on shell 
+     * @param matlabCommand MATLAB command to execute on shell
      * @return matlabLauncher returns the process launcher to run MATLAB commands
      */
-    default ProcStarter getProcessToRunMatlabCommand(FilePath workspace, Launcher launcher,TaskListener listener, EnvVars envVars, String matlabCommand,String uniqueName) throws IOException, InterruptedException {
-        //Get node specific tmp directory to copy matlab runner script
+    default ProcStarter getProcessToRunMatlabCommand(FilePath workspace, Launcher launcher,
+            TaskListener listener, EnvVars envVars, String matlabCommand, String uniqueName)
+            throws IOException, InterruptedException {
+        // Get node specific tmp directory to copy matlab runner script
         String tmpDir = getNodeSpecificTmpFolderPath();
         FilePath targetWorkspace = new FilePath(launcher.getChannel(), tmpDir);
         ProcStarter matlabLauncher;
-        if(launcher.isUnix()) {
-        	final String runnerScriptName = uniqueName+"/run_matlab_command.sh";
-            matlabLauncher = launcher.launch().pwd(workspace).envs(envVars).cmds(tmpDir+"/"+runnerScriptName,matlabCommand).stdout(listener);
-            
-            //Copy runner .sh for linux platform in workspace.
-            copyFileInWorkspace(MatlabBuilderConstants.SHELL_RUNNER_SCRIPT, runnerScriptName, targetWorkspace);
-        }else {
-        	final String runnerScriptName = uniqueName+"\\run_matlab_command.bat";
-            launcher = launcher.decorateByPrefix("cmd.exe","/C");
-            matlabLauncher = launcher.launch().pwd(workspace).envs(envVars).cmds(tmpDir+"\\"+runnerScriptName,"\""+matlabCommand+"\"").stdout(listener);
-            //Copy runner.bat for Windows platform in workspace.
-            copyFileInWorkspace(MatlabBuilderConstants.BAT_RUNNER_SCRIPT, runnerScriptName, targetWorkspace);
+        if (launcher.isUnix()) {
+            final String runnerScriptName = uniqueName + "/run_matlab_command.sh";
+            matlabLauncher = launcher.launch().pwd(workspace).envs(envVars)
+                    .cmds(tmpDir + "/" + runnerScriptName, matlabCommand).stdout(listener);
+
+            // Copy runner .sh for linux platform in workspace.
+            copyFileInWorkspace(MatlabBuilderConstants.SHELL_RUNNER_SCRIPT, runnerScriptName,
+                    targetWorkspace);
+        } else {
+            final String runnerScriptName = uniqueName + "\\run_matlab_command.bat";
+            launcher = launcher.decorateByPrefix("cmd.exe", "/C");
+            matlabLauncher = launcher.launch().pwd(workspace).envs(envVars)
+                    .cmds(tmpDir + "\\" + runnerScriptName, "\"" + matlabCommand + "\"")
+                    .stdout(listener);
+            // Copy runner.bat for Windows platform in workspace.
+            copyFileInWorkspace(MatlabBuilderConstants.BAT_RUNNER_SCRIPT, runnerScriptName,
+                    targetWorkspace);
         }
         return matlabLauncher;
     }
@@ -54,35 +60,36 @@ public interface MatlabBuild {
     /*
      * Method to copy given file from source to target node specific workspace.
      */
-    default void copyFileInWorkspace(String sourceFile, String targetFile,
-            FilePath targetWorkspace) throws IOException, InterruptedException {
+    default void copyFileInWorkspace(String sourceFile, String targetFile, FilePath targetWorkspace)
+            throws IOException, InterruptedException {
         final ClassLoader classLoader = getClass().getClassLoader();
         FilePath targetFilePath = new FilePath(targetWorkspace, targetFile);
         InputStream in = classLoader.getResourceAsStream(sourceFile);
         targetFilePath.copyFrom(in);
         // set executable permission
-        targetFilePath.chmod(0755);       
+        targetFilePath.chmod(0755);
     }
-    
-    default FilePath getNodeSpecificMatlabRunnerScript(Launcher launcher,String uniqueName) throws IOException, InterruptedException {
+
+    default FilePath getFilePathForUniqueFolder(Launcher launcher, String uniqueName)
+            throws IOException, InterruptedException {
         Computer cmp = Computer.currentComputer();
         String tmpDir = (String) cmp.getSystemProperties().get("java.io.tmpdir");
-        if(launcher.isUnix()) {
-            tmpDir = tmpDir+"/"+uniqueName;
-        }else {
-            tmpDir = tmpDir+"\\"+uniqueName;
+        if (launcher.isUnix()) {
+            tmpDir = tmpDir + "/" + uniqueName;
+        } else {
+            tmpDir = tmpDir + "\\" + uniqueName;
         }
-        return new FilePath(launcher.getChannel(), tmpDir);   
+        return new FilePath(launcher.getChannel(), tmpDir);
     }
-    
+
     default String getNodeSpecificTmpFolderPath() throws IOException, InterruptedException {
         Computer cmp = Computer.currentComputer();
         String tmpDir = (String) cmp.getSystemProperties().get("java.io.tmpdir");
         return tmpDir;
     }
-    
+
     default String getUniqueNameForRunnerFile() {
-    	return UUID.randomUUID().toString();
+        return UUID.randomUUID().toString();
     }
 
 }

--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -9,7 +9,7 @@ package com.mathworks.ci;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Instant;
+import java.util.UUID;
 
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -36,13 +36,13 @@ public interface MatlabBuild {
         FilePath targetWorkspace = new FilePath(launcher.getChannel(), tmpDir);
         ProcStarter matlabLauncher;
         if(launcher.isUnix()) {
-        	final String runnerScriptName = "run_matlab_command"+uniqueName+".sh";
+        	final String runnerScriptName = uniqueName+"/run_matlab_command.sh";
             matlabLauncher = launcher.launch().pwd(workspace).envs(envVars).cmds(tmpDir+"/"+runnerScriptName,matlabCommand).stdout(listener);
             
             //Copy runner .sh for linux platform in workspace.
             copyFileInWorkspace(MatlabBuilderConstants.SHELL_RUNNER_SCRIPT, runnerScriptName, targetWorkspace);
         }else {
-        	final String runnerScriptName = "run_matlab_command"+uniqueName+".bat";
+        	final String runnerScriptName = uniqueName+"\\run_matlab_command.bat";
             launcher = launcher.decorateByPrefix("cmd.exe","/C");
             matlabLauncher = launcher.launch().pwd(workspace).envs(envVars).cmds(tmpDir+"\\"+runnerScriptName,"\""+matlabCommand+"\"").stdout(listener);
             //Copy runner.bat for Windows platform in workspace.
@@ -68,9 +68,9 @@ public interface MatlabBuild {
         Computer cmp = Computer.currentComputer();
         String tmpDir = (String) cmp.getSystemProperties().get("java.io.tmpdir");
         if(launcher.isUnix()) {
-            tmpDir = tmpDir+"/run_matlab_command"+uniqueName+".sh";
+            tmpDir = tmpDir+"/"+uniqueName;
         }else {
-            tmpDir = tmpDir+"\\"+"run_matlab_command"+uniqueName+".bat";
+            tmpDir = tmpDir+"\\"+uniqueName;
         }
         return new FilePath(launcher.getChannel(), tmpDir);   
     }
@@ -82,7 +82,7 @@ public interface MatlabBuild {
     }
     
     default String getUniqueNameForRunnerFile() {
-    	return Instant.now().toString().replaceAll("[:,.]", "");
+    	return UUID.randomUUID().toString();
     }
 
 }

--- a/src/main/java/com/mathworks/ci/RunMatlabCommandBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabCommandBuilder.java
@@ -7,7 +7,6 @@ package com.mathworks.ci;
  */
 
 import java.io.IOException;
-
 import javax.annotation.Nonnull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -96,37 +95,38 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep,
     public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace,
             @Nonnull Launcher launcher, @Nonnull TaskListener listener)
             throws InterruptedException, IOException {
-     
-            // Set the environment variable specific to the this build
-            setEnv(build.getEnvironment(listener));
 
-            // Invoke MATLAB command and transfer output to standard
-            // Output Console
+        // Set the environment variable specific to the this build
+        setEnv(build.getEnvironment(listener));
 
-            buildResult = execMatlabCommand(workspace, launcher, listener, getEnv());
+        // Invoke MATLAB command and transfer output to standard
+        // Output Console
 
-            if (buildResult != 0) {
-                build.setResult(Result.FAILURE);
-            }
+        buildResult = execMatlabCommand(workspace, launcher, listener, getEnv());
+
+        if (buildResult != 0) {
+            build.setResult(Result.FAILURE);
+        }
     }
 
     private synchronized int execMatlabCommand(FilePath workspace, Launcher launcher,
             TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
-    	final String uniqueTmpFldrName = getUniqueNameForRunnerFile();
+        final String uniqueTmpFldrName = getUniqueNameForRunnerFile();
         ProcStarter matlabLauncher;
         try {
-            matlabLauncher = getProcessToRunMatlabCommand(workspace, launcher, listener, envVars,getCommand(),uniqueTmpFldrName);
+            matlabLauncher = getProcessToRunMatlabCommand(workspace, launcher, listener, envVars,
+                    getCommand(), uniqueTmpFldrName);
             return matlabLauncher.join();
         } catch (Exception e) {
             listener.getLogger().println(e.getMessage());
             return 1;
-        }finally {
-        	// Cleanup the runner File from tmp directory
-        	FilePath matlabRunnerScript = getNodeSpecificMatlabRunnerScript(launcher,uniqueTmpFldrName);
-            if(matlabRunnerScript.isDirectory()) {
+        } finally {
+            // Cleanup the runner File from tmp directory
+            FilePath matlabRunnerScript = getFilePathForUniqueFolder(launcher, uniqueTmpFldrName);
+            if (matlabRunnerScript.exists()) {
                 matlabRunnerScript.deleteRecursive();
             }
         }
-        
-    } 
+
+    }
 }

--- a/src/main/java/com/mathworks/ci/RunMatlabCommandBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabCommandBuilder.java
@@ -122,7 +122,8 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep,
             return 1;
         } finally {
             // Cleanup the runner File from tmp directory
-            FilePath matlabRunnerScript = getFilePathForUniqueFolder(launcher, uniqueTmpFldrName);
+            FilePath matlabRunnerScript =
+                    getFilePathForUniqueFolder(launcher, uniqueTmpFldrName, workspace);
             if (matlabRunnerScript.exists()) {
                 matlabRunnerScript.deleteRecursive();
             }

--- a/src/main/java/com/mathworks/ci/RunMatlabCommandBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabCommandBuilder.java
@@ -7,7 +7,6 @@ package com.mathworks.ci;
  */
 
 import java.io.IOException;
-import java.time.Instant;
 
 import javax.annotation.Nonnull;
 import org.jenkinsci.Symbol;
@@ -113,19 +112,19 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep,
 
     private synchronized int execMatlabCommand(FilePath workspace, Launcher launcher,
             TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
-    	final String uniqueFileName = getUniqueNameForRunnerFile();
+    	final String uniqueTmpFldrName = getUniqueNameForRunnerFile();
         ProcStarter matlabLauncher;
         try {
-            matlabLauncher = getProcessToRunMatlabCommand(workspace, launcher, listener, envVars,getCommand(),uniqueFileName);
+            matlabLauncher = getProcessToRunMatlabCommand(workspace, launcher, listener, envVars,getCommand(),uniqueTmpFldrName);
             return matlabLauncher.join();
         } catch (Exception e) {
             listener.getLogger().println(e.getMessage());
             return 1;
         }finally {
         	// Cleanup the runner File from tmp directory
-        	FilePath matlabRunnerScript = getNodeSpecificMatlabRunnerScript(launcher,uniqueFileName);
-            if(matlabRunnerScript.exists()) {
-                matlabRunnerScript.delete();
+        	FilePath matlabRunnerScript = getNodeSpecificMatlabRunnerScript(launcher,uniqueTmpFldrName);
+            if(matlabRunnerScript.isDirectory()) {
+                matlabRunnerScript.deleteRecursive();
             }
         }
         

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -3,7 +3,8 @@ package com.mathworks.ci;
 /**
  * Copyright 2019-2020 The MathWorks, Inc.
  * 
- * MATLAB test run builder used to run all MATLAB & Simulink tests automatically and generate selected test artifacts.
+ * MATLAB test run builder used to run all MATLAB & Simulink tests automatically and generate
+ * selected test artifacts.
  * 
  */
 
@@ -37,8 +38,8 @@ import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 
-public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep,MatlabBuild {
-    
+public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, MatlabBuild {
+
     private int buildResult;
     private EnvVars env;
     private boolean tapChkBx;
@@ -72,22 +73,22 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep,Ma
     public void setCoberturaChkBx(boolean coberturaChkBx) {
         this.coberturaChkBx = coberturaChkBx;
     }
-    
+
     @DataBoundSetter
     public void setStmResultsChkBx(boolean stmResultsChkBx) {
         this.stmResultsChkBx = stmResultsChkBx;
     }
-    
+
     @DataBoundSetter
     public void setModelCoverageChkBx(boolean modelCoverageChkBx) {
         this.modelCoverageChkBx = modelCoverageChkBx;
     }
-    
+
     @DataBoundSetter
     public void setPdfReportChkBx(boolean pdfReportChkBx) {
         this.pdfReportChkBx = pdfReportChkBx;
     }
-            
+
     public boolean getTapChkBx() {
         return tapChkBx;
     }
@@ -103,29 +104,29 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep,Ma
     public boolean getStmResultsChkBx() {
         return stmResultsChkBx;
     }
-            
+
     public boolean getModelCoverageChkBx() {
         return modelCoverageChkBx;
     }
-    
+
     public boolean getPdfReportChkBx() {
         return pdfReportChkBx;
     }
-    
+
     private void setEnv(EnvVars env) {
         this.env = env;
     }
-    
+
     private EnvVars getEnv() {
         return this.env;
     }
-    
+
     @Symbol("RunMatlabTests")
     @Extension
     public static class RunMatlabTestsDescriptor extends BuildStepDescriptor<Builder> {
-        
+
         MatlabReleaseInfo rel;
-        
+
         // Overridden Method used to show the text under build dropdown
         @Override
         public String getDisplayName() {
@@ -146,18 +147,19 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep,Ma
          * if it returns true then this build step will be applicable for all project type.
          */
         @Override
-        public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobtype) {
+        public boolean isApplicable(
+                @SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobtype) {
             return true;
         }
-        
-        
+
+
         /*
          * Validation for Test artifact generator checkBoxes
          */
-        
-        //Get the MATLAB root entered in build wrapper descriptor 
-        
-        
+
+        // Get the MATLAB root entered in build wrapper descriptor
+
+
 
         public FormValidation doCheckCoberturaChkBx(@QueryParameter boolean coberturaChkBx) {
             List<Function<String, FormValidation>> listOfCheckMethods =
@@ -165,119 +167,127 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep,Ma
             if (coberturaChkBx) {
                 listOfCheckMethods.add(chkCoberturaSupport);
             }
-            return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods,getMatlabRoot());
+            return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods, getMatlabRoot());
         }
 
         Function<String, FormValidation> chkCoberturaSupport = (String matlabRoot) -> {
             FilePath matlabRootPath = new FilePath(new File(matlabRoot));
             rel = new MatlabReleaseInfo(matlabRootPath);
             final MatrixPatternResolver resolver = new MatrixPatternResolver(matlabRoot);
-            if(!resolver.hasVariablePattern()) {
+            if (!resolver.hasVariablePattern()) {
                 try {
-                    if (rel.verLessThan(MatlabBuilderConstants.BASE_MATLAB_VERSION_COBERTURA_SUPPORT)) {
-                        return FormValidation
-                                .warning(Message.getValue("Builder.matlab.cobertura.support.warning"));
+                    if (rel.verLessThan(
+                            MatlabBuilderConstants.BASE_MATLAB_VERSION_COBERTURA_SUPPORT)) {
+                        return FormValidation.warning(
+                                Message.getValue("Builder.matlab.cobertura.support.warning"));
                     }
                 } catch (MatlabVersionNotFoundException e) {
-                    return FormValidation.warning(Message.getValue("Builder.invalid.matlab.root.warning"));
+                    return FormValidation
+                            .warning(Message.getValue("Builder.invalid.matlab.root.warning"));
                 }
             }
-            
+
 
             return FormValidation.ok();
         };
-        
-        public FormValidation doCheckModelCoverageChkBx(@QueryParameter boolean modelCoverageChkBx) {
+
+        public FormValidation doCheckModelCoverageChkBx(
+                @QueryParameter boolean modelCoverageChkBx) {
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();
             if (modelCoverageChkBx) {
                 listOfCheckMethods.add(chkModelCoverageSupport);
             }
-            return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods,getMatlabRoot());
+            return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods, getMatlabRoot());
         }
-        
+
         Function<String, FormValidation> chkModelCoverageSupport = (String matlabRoot) -> {
             FilePath matlabRootPath = new FilePath(new File(matlabRoot));
             rel = new MatlabReleaseInfo(matlabRootPath);
             final MatrixPatternResolver resolver = new MatrixPatternResolver(matlabRoot);
-            if(!resolver.hasVariablePattern()) {
+            if (!resolver.hasVariablePattern()) {
                 try {
-                    if (rel.verLessThan(MatlabBuilderConstants.BASE_MATLAB_VERSION_MODELCOVERAGE_SUPPORT)) {
-                        return FormValidation
-                                .warning(Message.getValue("Builder.matlab.modelcoverage.support.warning"));
+                    if (rel.verLessThan(
+                            MatlabBuilderConstants.BASE_MATLAB_VERSION_MODELCOVERAGE_SUPPORT)) {
+                        return FormValidation.warning(
+                                Message.getValue("Builder.matlab.modelcoverage.support.warning"));
                     }
                 } catch (MatlabVersionNotFoundException e) {
-                    return FormValidation.warning(Message.getValue("Builder.invalid.matlab.root.warning"));
+                    return FormValidation
+                            .warning(Message.getValue("Builder.invalid.matlab.root.warning"));
                 }
             }
-            
-            
+
+
             return FormValidation.ok();
         };
-        
+
         public FormValidation doCheckStmResultsChkBx(@QueryParameter boolean stmResultsChkBx) {
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();
             if (stmResultsChkBx) {
                 listOfCheckMethods.add(chkSTMResultsSupport);
             }
-            return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods,getMatlabRoot());
+            return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods, getMatlabRoot());
         }
-        
+
         Function<String, FormValidation> chkSTMResultsSupport = (String matlabRoot) -> {
             FilePath matlabRootPath = new FilePath(new File(matlabRoot));
             rel = new MatlabReleaseInfo(matlabRootPath);
             final MatrixPatternResolver resolver = new MatrixPatternResolver(matlabRoot);
-            if(!resolver.hasVariablePattern()) {
+            if (!resolver.hasVariablePattern()) {
                 try {
-                    if (rel.verLessThan(MatlabBuilderConstants.BASE_MATLAB_VERSION_EXPORTSTMRESULTS_SUPPORT)) {
-                        return FormValidation
-                                .warning(Message.getValue("Builder.matlab.exportstmresults.support.warning"));
+                    if (rel.verLessThan(
+                            MatlabBuilderConstants.BASE_MATLAB_VERSION_EXPORTSTMRESULTS_SUPPORT)) {
+                        return FormValidation.warning(Message
+                                .getValue("Builder.matlab.exportstmresults.support.warning"));
                     }
                 } catch (MatlabVersionNotFoundException e) {
-                    return FormValidation.warning(Message.getValue("Builder.invalid.matlab.root.warning"));
+                    return FormValidation
+                            .warning(Message.getValue("Builder.invalid.matlab.root.warning"));
                 }
             }
             return FormValidation.ok();
         };
-        
-        //Method to get the MatlabRoot value from Build wrapper class.
+
+        // Method to get the MatlabRoot value from Build wrapper class.
         public static String getMatlabRoot() {
             try {
                 return Jenkins.getInstance().getDescriptorByType(UseMatlabVersionDescriptor.class)
                         .getMatlabRootFolder();
             } catch (Exception e) {
-                // For any exception during getMatlabRootFolder() operation, return matlabRoot as NULL.
+                // For any exception during getMatlabRootFolder() operation, return matlabRoot as
+                // NULL.
                 return null;
             }
         }
-     }
+    }
 
     @Override
     public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace,
             @Nonnull Launcher launcher, @Nonnull TaskListener listener)
             throws InterruptedException, IOException {
 
-            // Set the environment variable specific to the this build
-            setEnv(build.getEnvironment(listener));
+        // Set the environment variable specific to the this build
+        setEnv(build.getEnvironment(listener));
 
-            // Invoke MATLAB command and transfer output to standard
-            // Output Console
+        // Invoke MATLAB command and transfer output to standard
+        // Output Console
 
-            buildResult = execMatlabCommand(workspace, launcher, listener, getEnv());
+        buildResult = execMatlabCommand(workspace, launcher, listener, getEnv());
 
-            if (buildResult != 0) {
-                build.setResult(Result.FAILURE);
-            }      
+        if (buildResult != 0) {
+            build.setResult(Result.FAILURE);
+        }
     }
 
     private synchronized int execMatlabCommand(FilePath workspace, Launcher launcher,
             TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
-    	final String uniqueTmpFldrName = getUniqueNameForRunnerFile();
+        final String uniqueTmpFldrName = getUniqueNameForRunnerFile();
         ProcStarter matlabLauncher;
         try {
             matlabLauncher = getProcessToRunMatlabCommand(workspace, launcher, listener, envVars,
-                    constructCommandForTest(getInputArguments()),uniqueTmpFldrName);
+                    constructCommandForTest(getInputArguments()), uniqueTmpFldrName);
 
             // Copy MATLAB scratch file into the workspace.
             FilePath targetWorkspace = new FilePath(launcher.getChannel(), workspace.getRemote());
@@ -287,34 +297,38 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep,Ma
         } catch (Exception e) {
             listener.getLogger().println(e.getMessage());
             return 1;
-        }finally {
+        } finally {
             // Cleanup the runner File from tmp directory
-            FilePath matlabRunnerScript = getNodeSpecificMatlabRunnerScript(launcher,uniqueTmpFldrName);
-            if (matlabRunnerScript.isDirectory()) {
+            FilePath matlabRunnerScript = getFilePathForUniqueFolder(launcher, uniqueTmpFldrName);
+            if (matlabRunnerScript.exists()) {
                 matlabRunnerScript.deleteRecursive();
             }
         }
-        
+
     }
-    
+
     public String constructCommandForTest(String inputArguments) {
         final String matlabFunctionName = FilenameUtils.removeExtension(
                 Message.getValue(MatlabBuilderConstants.MATLAB_RUNNER_TARGET_FILE));
         final String runCommand = "exit(" + matlabFunctionName + "(" + inputArguments + "))";
         return runCommand;
-    }   
-    
+    }
+
     // Concatenate the input arguments
     private String getInputArguments() {
         final String pdfReport = MatlabBuilderConstants.PDF_REPORT + "," + this.getPdfReportChkBx();
         final String tapResults = MatlabBuilderConstants.TAP_RESULTS + "," + this.getTapChkBx();
-        final String junitResults = MatlabBuilderConstants.JUNIT_RESULTS + "," + this.getJunitChkBx();
-        final String stmResults = MatlabBuilderConstants.STM_RESULTS + "," + this.getStmResultsChkBx();
-        final String coberturaCodeCoverage = MatlabBuilderConstants.COBERTURA_CODE_COVERAGE + "," + this.getCoberturaChkBx();
-        final String coberturaModelCoverage = MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE + "," + this.getModelCoverageChkBx();    
+        final String junitResults =
+                MatlabBuilderConstants.JUNIT_RESULTS + "," + this.getJunitChkBx();
+        final String stmResults =
+                MatlabBuilderConstants.STM_RESULTS + "," + this.getStmResultsChkBx();
+        final String coberturaCodeCoverage =
+                MatlabBuilderConstants.COBERTURA_CODE_COVERAGE + "," + this.getCoberturaChkBx();
+        final String coberturaModelCoverage = MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE + ","
+                + this.getModelCoverageChkBx();
         final String inputArgsToMatlabFcn = pdfReport + "," + tapResults + "," + junitResults + ","
                 + stmResults + "," + coberturaCodeCoverage + "," + coberturaModelCoverage;
-  
+
         return inputArgsToMatlabFcn;
     }
 }

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -10,7 +10,6 @@ package com.mathworks.ci;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -274,11 +273,11 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep,Ma
 
     private synchronized int execMatlabCommand(FilePath workspace, Launcher launcher,
             TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
-    	final String uniqueFileName = getUniqueNameForRunnerFile();
+    	final String uniqueTmpFldrName = getUniqueNameForRunnerFile();
         ProcStarter matlabLauncher;
         try {
             matlabLauncher = getProcessToRunMatlabCommand(workspace, launcher, listener, envVars,
-                    constructCommandForTest(getInputArguments()),uniqueFileName);
+                    constructCommandForTest(getInputArguments()),uniqueTmpFldrName);
 
             // Copy MATLAB scratch file into the workspace.
             FilePath targetWorkspace = new FilePath(launcher.getChannel(), workspace.getRemote());
@@ -290,9 +289,9 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep,Ma
             return 1;
         }finally {
             // Cleanup the runner File from tmp directory
-            FilePath matlabRunnerScript = getNodeSpecificMatlabRunnerScript(launcher,uniqueFileName);
-            if (matlabRunnerScript.exists()) {
-                matlabRunnerScript.delete();
+            FilePath matlabRunnerScript = getNodeSpecificMatlabRunnerScript(launcher,uniqueTmpFldrName);
+            if (matlabRunnerScript.isDirectory()) {
+                matlabRunnerScript.deleteRecursive();
             }
         }
         

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -299,12 +299,12 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             return 1;
         } finally {
             // Cleanup the runner File from tmp directory
-            FilePath matlabRunnerScript = getFilePathForUniqueFolder(launcher, uniqueTmpFldrName);
+            FilePath matlabRunnerScript =
+                    getFilePathForUniqueFolder(launcher, uniqueTmpFldrName, workspace);
             if (matlabRunnerScript.exists()) {
                 matlabRunnerScript.deleteRecursive();
             }
         }
-
     }
 
     public String constructCommandForTest(String inputArguments) {

--- a/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
+++ b/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
@@ -13,10 +13,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -30,7 +32,8 @@ import jenkins.tasks.SimpleBuildWrapper;
 
 public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
 
-    private String matlabRootFolder;
+    
+	private String matlabRootFolder;
     private EnvVars env;
 
     @DataBoundConstructor
@@ -124,7 +127,7 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
     }
 
     @Override
-    public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher,
+    public synchronized void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher,
             TaskListener listener, EnvVars initialEnvironment)
             throws IOException, InterruptedException {
         // Set Environment variable
@@ -134,9 +137,9 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
         // Add "matlabroot" without bin as env variable which will be available across the build.
         context.env("matlabroot", getLocalMatlab());
         // Add matlab bin to path to invoke MATLAB directly on command line.
-        context.env("PATH+matlabroot", getLocalMatlab() + nodeSpecificFileSep + "bin");
+        context.env("PATH+matlabroot", getLocalMatlab() + nodeSpecificFileSep + "bin");     
     }
-    
+
     private String getNodeSpecificFileSeperator(Launcher launcher) {
         if (launcher.isUnix()) {
             return "/";

--- a/src/test/java/com/mathworks/ci/RunMatlabCommandBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabCommandBuilderTest.java
@@ -11,7 +11,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.After;
 import org.junit.Assert;
@@ -21,6 +23,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import hudson.EnvVars;
+import hudson.matrix.Axis;
+import hudson.matrix.AxisList;
+import hudson.matrix.Combination;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixRun;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
@@ -233,4 +241,54 @@ public class RunMatlabCommandBuilderTest {
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertLogContains("MATLAB_ROOT", build);
     }
+    
+	/*
+	 * Test to verify if Matrix build fails when MATLAB is not available.
+	 */
+	@Test
+	public void verifyMatrixBuildFails() throws Exception {
+		MatrixProject matrixProject = jenkins.createProject(MatrixProject.class);
+		Axis axes = new Axis("VERSION", "R2018a", "R2018b");
+		matrixProject.setAxes(new AxisList(axes));
+		String matlabRoot = getMatlabroot("R2018b");
+		this.buildWrapper.setMatlabRootFolder(matlabRoot.replace("R2018b", "$VERSION"));
+		matrixProject.getBuildWrappersList().add(this.buildWrapper);
+
+		scriptBuilder.setMatlabCommand("pwd");
+		matrixProject.getBuildersList().add(scriptBuilder);
+		Map<String, String> vals = new HashMap<String, String>();
+		vals.put("VERSION", "R2018a");
+		Combination c1 = new Combination(vals);
+		MatrixRun build = matrixProject.scheduleBuild2(0).get().getRun(c1);
+		jenkins.assertLogContains("MATLAB_ROOT", build);
+		jenkins.assertBuildStatus(Result.FAILURE, build);
+		vals.put("VERSION", "R2018b");
+		Combination c2 = new Combination(vals);
+		MatrixRun build2 = matrixProject.scheduleBuild2(0).get().getRun(c2);
+		jenkins.assertLogContains("MATLAB_ROOT", build2);
+		jenkins.assertBuildStatus(Result.FAILURE, build2);
+	}
+
+	/*
+	 * Test to verify if Matrix build passes (mock MATLAB).
+	 */
+	@Test
+	public void verifyMatrixBuildPasses() throws Exception {
+		MatrixProject matrixProject = jenkins.createProject(MatrixProject.class);
+		Axis axes = new Axis("VERSION", "R2018a", "R2018b");
+		matrixProject.setAxes(new AxisList(axes));
+		String matlabRoot = getMatlabroot("R2018b");
+		this.buildWrapper.setMatlabRootFolder(matlabRoot.replace("R2018b", "$VERSION"));
+		matrixProject.getBuildWrappersList().add(this.buildWrapper);
+		RunMatlabCommandBuilderTester tester = new RunMatlabCommandBuilderTester(matlabExecutorAbsolutePath,
+				"-positive");
+
+		tester.setMatlabCommand("pwd");
+		matrixProject.getBuildersList().add(tester);
+		MatrixBuild build = matrixProject.scheduleBuild2(0).get();
+
+		jenkins.assertLogContains("R2018a completed", build);
+		jenkins.assertLogContains("R2018b completed", build);
+		jenkins.assertBuildStatus(Result.SUCCESS, build);
+	}
 }

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
@@ -228,19 +228,6 @@ public class RunMatlabTestsBuilderTest {
                 + "\'CoberturaCodeCoverage\',true,\'CoberturaModelCoverage\',true", build);
     }
 
-    /*
-     * Test to verify if MATALB scratch file is generated in workspace.
-     */
-    @Test
-    public void verifyMATLABscratchFileGeneratedForAutomaticOption() throws Exception {
-        this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2018b"));
-        project.getBuildWrappersList().add(this.buildWrapper);
-        setAllTestArtifacts(false, testBuilder);
-        project.getBuildersList().add(testBuilder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
-        File matlabRunner = new File(build.getWorkspace() + File.separator + "runMatlabTests.m");
-        Assert.assertTrue(matlabRunner.exists());
-    }
     
     /*
      * Test to verify if appropriate MATALB runner file is copied in workspace.


### PR DESCRIPTION
Matrix builds were failing due to synchronization issue . since mtalb_runner script was used by both builds with same name and same location .  the namespacing issue caused accidental deletion of the runner script by by different thread than it had create. Resolved this issue by letting each build step to copy its own file in tmp folder and delete the same file. File uniqueness is mainatined by adding a timeStamp to the file name.  