### PR TITLE
fixed findbug issue and Scratch file copy issue.

### DIFF
--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -9,6 +9,8 @@ package com.mathworks.ci;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
+import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -70,7 +72,9 @@ public interface MatlabBuild {
         targetFilePath.chmod(0755);
     }
 
-    default FilePath getFilePathForUniqueFolder(Launcher launcher, String uniqueName,FilePath workspace)
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            justification = "workspace is passed through perform method, which will always have NonNull FilePath")
+    default FilePath getFilePathForUniqueFolder(Launcher launcher, String uniqueName, FilePath workspace)
             throws IOException, InterruptedException {
         /*Use of Computer is not recommended as jenkins hygeine for pipeline support
          * https://javadoc.jenkins-ci.org/jenkins/tasks/SimpleBuildStep.html */
@@ -85,6 +89,8 @@ public interface MatlabBuild {
         return new FilePath(launcher.getChannel(), tmpDir);
     }
 
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            justification = "workspace is passed through perform method, which will always have NonNull FilePath")
     default String getNodeSpecificTmpFolderPath(FilePath workspace) throws IOException, InterruptedException {
         Computer cmp = workspace.toComputer();
         String tmpDir = (String) cmp.getSystemProperties().get("java.io.tmpdir");

--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -76,12 +76,7 @@ public interface MatlabBuild {
          * https://javadoc.jenkins-ci.org/jenkins/tasks/SimpleBuildStep.html */
         
         String tmpDir = getNodeSpecificTmpFolderPath(workspace);
-        if (launcher.isUnix()) {
-            tmpDir = tmpDir + "/" + uniqueName;
-        } else {
-            tmpDir = tmpDir + "\\" + uniqueName;
-        }
-        return new FilePath(launcher.getChannel(), tmpDir);
+        return new FilePath(launcher.getChannel(), tmpDir+"/"+uniqueName);
     }
 
     default String getNodeSpecificTmpFolderPath(FilePath workspace) throws IOException, InterruptedException {

--- a/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
@@ -12,6 +12,7 @@ public class MatlabBuilderConstants {
     static final double BASE_MATLAB_VERSION_EXPORTSTMRESULTS_SUPPORT = 9.6;
     
     static final String MATLAB_RUNNER_TARGET_FILE = "Builder.matlab.runner.target.file.name";
+    static final String MATLAB_TESTS_RUNNER_TARGET_FILE = "runMatlabTests.m";
     static final String MATLAB_RUNNER_RESOURCE = "com/mathworks/ci/MatlabBuilder/runMatlabTests.m";
     static final String AUTOMATIC_OPTION = "RunTestsAutomaticallyOption";
     

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -292,7 +292,7 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             // Copy MATLAB scratch file into the workspace.
             FilePath targetWorkspace = new FilePath(launcher.getChannel(), workspace.getRemote());
             copyFileInWorkspace(MatlabBuilderConstants.MATLAB_RUNNER_RESOURCE,
-                    MatlabBuilderConstants.MATLAB_RUNNER_TARGET_FILE, targetWorkspace);
+                    MatlabBuilderConstants.MATLAB_TESTS_RUNNER_TARGET_FILE, targetWorkspace);
             return matlabLauncher.join();
         } catch (Exception e) {
             listener.getLogger().println(e.getMessage());
@@ -308,8 +308,8 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
     }
 
     public String constructCommandForTest(String inputArguments) {
-        final String matlabFunctionName = FilenameUtils.removeExtension(
-                Message.getValue(MatlabBuilderConstants.MATLAB_RUNNER_TARGET_FILE));
+        final String matlabFunctionName =
+                FilenameUtils.removeExtension(MatlabBuilderConstants.MATLAB_TESTS_RUNNER_TARGET_FILE);
         final String runCommand = "exit(" + matlabFunctionName + "(" + inputArguments + "))";
         return runCommand;
     }

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -16,4 +16,5 @@ Builder.matlab.modelcoverage.support.warning = To generate a Cobertura model cov
 Builder.matlab.exportstmresults.support.warning = To export Simulink Test Manager results, use MATLAB R2019a or a newer release.
 Builder.matlab.runner.script.target.file.linux.name = run_matlab_command.sh
 Builder.matlab.runner.script.target.file.windows.name = run_matlab_command.bat
+build.workspace.computer.not.found = Unable to get the current computer for this build.
 

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -16,5 +16,4 @@ Builder.matlab.modelcoverage.support.warning = To generate a Cobertura model cov
 Builder.matlab.exportstmresults.support.warning = To export Simulink Test Manager results, use MATLAB R2019a or a newer release.
 Builder.matlab.runner.script.target.file.linux.name = run_matlab_command.sh
 Builder.matlab.runner.script.target.file.windows.name = run_matlab_command.bat
-build.workspace.computer.not.found = Unable to get the current computer for this build.
-
+build.workspace.computer.not.found = Unable to access the computer for this build.

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
@@ -26,6 +26,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import com.gargoylesoftware.htmlunit.WebAssert;
 import com.gargoylesoftware.htmlunit.html.HtmlCheckBoxInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.mathworks.ci.MatlabBuilder.RunTestsAutomaticallyOption;
 import hudson.FilePath;
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
@@ -307,6 +308,20 @@ public class RunMatlabTestsBuilderTest {
 		jenkins.assertLogContains("R2018b completed", build);
 		jenkins.assertBuildStatus(Result.SUCCESS, build);
 	}
+	
+	 /*
+     * Test to verify if MATALB scratch file is generated in workspace.
+     */
+    @Test
+    public void verifyMATLABscratchFileGenerated() throws Exception {
+        this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2018b"));  
+        project.getBuildWrappersList().add(this.buildWrapper);
+        setAllTestArtifacts(false, testBuilder);
+        project.getBuildersList().add(testBuilder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        File matlabRunner = new File(build.getWorkspace() + File.separator + "runMatlabTests.m");
+        Assert.assertTrue(matlabRunner.exists());
+    }
 
 
     /*


### PR DESCRIPTION
Fixed the Findbug issue . suppressed the warning as workspace is always passed  through perform() method of builder which will always have workspace available. 

Also there is fix for  matlab scratch file copy issue due to new changes in copyMethod () 
test to check the if scratch file is copied in workspace was missing from new RunMatlabTestsBuilder class which is added now.