### PR TITLE
Use latest Mac image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ strategy:
     linux:
       imageName: 'ubuntu-16.04'
     mac:
-      imageName: 'macos-10.13'
+      imageName: 'macOS-10.15'
     windows:
       imageName: 'vs2017-win2016'
 


### PR DESCRIPTION
Fix our failing Mac builds by using a latest supported Mac image