### PR TITLE
Artifact input change nop

### DIFF
--- a/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
@@ -13,6 +13,7 @@ public class MatlabBuilderConstants {
     
     static final String MATLAB_RUNNER_TARGET_FILE = "Builder.matlab.runner.target.file.name";
     static final String MATLAB_TESTS_RUNNER_TARGET_FILE = "runMatlabTests.m";
+    static final String MATLAB_TESTS_RUNNER_RESOURCE = "com/mathworks/ci/RunMatlabTestsBuilder/runMatlabTests.m";
     static final String MATLAB_RUNNER_RESOURCE = "com/mathworks/ci/MatlabBuilder/runMatlabTests.m";
     static final String AUTOMATIC_OPTION = "RunTestsAutomaticallyOption";
     
@@ -23,6 +24,12 @@ public class MatlabBuilderConstants {
     static final String STM_RESULTS = "'SimulinkTestResults'";
     static final String COBERTURA_CODE_COVERAGE = "'CoberturaCodeCoverage'";
     static final String COBERTURA_MODEL_COVERAGE = "'CoberturaModelCoverage'";
+    static final String PDF_REPORT_PATH = "'PDFReportPath'";
+    static final String TAP_RESULTS_PATH ="'TAPResultsPath'";
+    static final String JUNIT_RESULTS_PATH = "'JUnitResultsPath'";
+    static final String STM_RESULTS_PATH = "'SimulinkTestResultsPath'";
+    static final String COBERTURA_CODE_COVERAGE_PATH = "'CoberturaCodeCoveragePath'";
+    static final String COBERTURA_MODEL_COVERAGE_PATH = "'CoberturaModelCoveragePath'";
     
     // Matlab Runner files 
     static final String BAT_RUNNER_SCRIPT = "run_matlab_command.bat";

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -1,27 +1,14 @@
 package com.mathworks.ci;
 
-/**
- * Copyright 2019-2020 The MathWorks, Inc.
- * 
- * MATLAB test run builder used to run all MATLAB & Simulink tests automatically and generate
- * selected test artifacts.
- * 
- */
-
-
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.FilenameUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
-import com.mathworks.ci.UseMatlabVersionBuildWrapper.UseMatlabVersionDescriptor;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -33,8 +20,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
-import hudson.util.FormValidation;
-import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 
@@ -202,8 +187,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
     @Extension
     public static class RunMatlabTestsDescriptor extends BuildStepDescriptor<Builder> {
 
-        MatlabReleaseInfo rel;
-
         // Overridden Method used to show the text under build dropdown
         @Override
         public String getDisplayName() {
@@ -227,116 +210,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public boolean isApplicable(
                 @SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobtype) {
             return true;
-        }
-
-
-        /*
-         * Validation for Test artifact generator checkBoxes
-         */
-
-        // Get the MATLAB root entered in build wrapper descriptor
-
-
-
-        public FormValidation doCheckCoberturaChkBxFilePath(@QueryParameter String coberturaChkBxFilePath) {
-            List<Function<String, FormValidation>> listOfCheckMethods =
-                    new ArrayList<Function<String, FormValidation>>();
-            if(!coberturaChkBxFilePath.isEmpty()) {
-                listOfCheckMethods.add(chkCoberturaSupport);
-            }
-            return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods, getMatlabRoot());
-        }
-
-        Function<String, FormValidation> chkCoberturaSupport = (String matlabRoot) -> {
-            FilePath matlabRootPath = new FilePath(new File(matlabRoot));
-            rel = new MatlabReleaseInfo(matlabRootPath);
-            final MatrixPatternResolver resolver = new MatrixPatternResolver(matlabRoot);
-            if (!resolver.hasVariablePattern()) {
-                try {
-                    if (rel.verLessThan(
-                            MatlabBuilderConstants.BASE_MATLAB_VERSION_COBERTURA_SUPPORT)) {
-                        return FormValidation.warning(
-                                Message.getValue("Builder.matlab.cobertura.support.warning"));
-                    }
-                } catch (MatlabVersionNotFoundException e) {
-                    return FormValidation
-                            .warning(Message.getValue("Builder.invalid.matlab.root.warning"));
-                }
-            }
-
-
-            return FormValidation.ok();
-        };
-                
-        public FormValidation doCheckModelCoverageChkBxFilePath(
-                @QueryParameter String modelCoverageChkBxFilePath) {
-            List<Function<String, FormValidation>> listOfCheckMethods =
-                    new ArrayList<Function<String, FormValidation>>();
-            if (!modelCoverageChkBxFilePath.isEmpty()) {
-                listOfCheckMethods.add(chkModelCoverageSupport);
-            }
-            return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods, getMatlabRoot());
-        }
-
-        Function<String, FormValidation> chkModelCoverageSupport = (String matlabRoot) -> {
-            FilePath matlabRootPath = new FilePath(new File(matlabRoot));
-            rel = new MatlabReleaseInfo(matlabRootPath);
-            final MatrixPatternResolver resolver = new MatrixPatternResolver(matlabRoot);
-            if (!resolver.hasVariablePattern()) {
-                try {
-                    if (rel.verLessThan(
-                            MatlabBuilderConstants.BASE_MATLAB_VERSION_MODELCOVERAGE_SUPPORT)) {
-                        return FormValidation.warning(
-                                Message.getValue("Builder.matlab.modelcoverage.support.warning"));
-                    }
-                } catch (MatlabVersionNotFoundException e) {
-                    return FormValidation
-                            .warning(Message.getValue("Builder.invalid.matlab.root.warning"));
-                }
-            }
-
-
-            return FormValidation.ok();
-        };
-
-        public FormValidation doCheckStmResultsChkBxFilePath(@QueryParameter String stmResultsChkBxFilePath) {
-            List<Function<String, FormValidation>> listOfCheckMethods =
-                    new ArrayList<Function<String, FormValidation>>();
-            if (!stmResultsChkBxFilePath.isEmpty()) {
-                listOfCheckMethods.add(chkSTMResultsSupport);
-            }
-            return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods, getMatlabRoot());
-        }
-
-        Function<String, FormValidation> chkSTMResultsSupport = (String matlabRoot) -> {
-            FilePath matlabRootPath = new FilePath(new File(matlabRoot));
-            rel = new MatlabReleaseInfo(matlabRootPath);
-            final MatrixPatternResolver resolver = new MatrixPatternResolver(matlabRoot);
-            if (!resolver.hasVariablePattern()) {
-                try {
-                    if (rel.verLessThan(
-                            MatlabBuilderConstants.BASE_MATLAB_VERSION_EXPORTSTMRESULTS_SUPPORT)) {
-                        return FormValidation.warning(Message
-                                .getValue("Builder.matlab.exportstmresults.support.warning"));
-                    }
-                } catch (MatlabVersionNotFoundException e) {
-                    return FormValidation
-                            .warning(Message.getValue("Builder.invalid.matlab.root.warning"));
-                }
-            }
-            return FormValidation.ok();
-        };
-
-        // Method to get the MatlabRoot value from Build wrapper class.
-        public static String getMatlabRoot() {
-            try {
-                return Jenkins.getInstance().getDescriptorByType(UseMatlabVersionDescriptor.class)
-                        .getMatlabRootFolder();
-            } catch (Exception e) {
-                // For any exception during getMatlabRootFolder() operation, return matlabRoot as
-                // NULL.
-                return null;
-            }
         }
     }
 
@@ -425,8 +298,8 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
      * 7Csort:date/jenkinsci-dev/AFYHSG3NUEI/UsVJIKoE4B8J
      * 
      */
-    public class PdfChkBx {
-        String pdfReportFilePath;
+    public static class PdfChkBx {
+        private String pdfReportFilePath;
 
         @DataBoundConstructor
         public PdfChkBx() {
@@ -443,8 +316,8 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         }
     }
 
-    public class TapChkBx {
-        String tapReportFilePath;
+    public static class TapChkBx {
+        private String tapReportFilePath;
 
         @DataBoundConstructor
         public TapChkBx() {
@@ -461,8 +334,8 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         }
     }
 
-    public class JunitChkBx {
-        String junitReportFilePath;
+    public static class JunitChkBx {
+        private String junitReportFilePath;
 
         @DataBoundConstructor
         public JunitChkBx() {
@@ -479,8 +352,8 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         }
     }
 
-    public class CoberturaChkBx {
-        String coberturaReportFilePath;
+    public static class CoberturaChkBx {
+        private String coberturaReportFilePath;
 
         @DataBoundConstructor
         public CoberturaChkBx() {
@@ -497,8 +370,8 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         }
     }
 
-    public class StmResultsChkBx {
-        String stmResultsFilePath;
+    public static class StmResultsChkBx {
+        private String stmResultsFilePath;
 
         @DataBoundConstructor
         public StmResultsChkBx() {
@@ -515,8 +388,8 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         }
     }
 
-    public class ModelCovChkBx {
-        String modelCoverageFilePath;
+    public static class ModelCovChkBx {
+        private String modelCoverageFilePath;
 
         @DataBoundConstructor
         public ModelCovChkBx() {

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -351,7 +351,7 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         }
 
         @Override
-        public boolean getDefault() {
+        public boolean getSelected() {
             return false;
         }
 
@@ -370,7 +370,7 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             this.filePath = path;
         }
 
-        public boolean getDefault() {
+        public boolean getSelected() {
             return true;
         }
 
@@ -389,6 +389,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
         public String getFilePath();
 
-        public boolean getDefault();
+        public boolean getSelected();
     }
 }

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -18,6 +18,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.w3c.dom.views.AbstractView;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -36,20 +37,13 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
     private int buildResult;
     private EnvVars env;
-    private TapArtifact tapArtifact;
-    private JunitArtifact junitArtifact;   
-    private CoberturaArtifact coberturaArtifact;
-    private StmResultsArtifact stmResultsArtifact; 
-    private ModelCovArtifact modelCoverageArtifact; 
-    private PdfArtifact pdfReportArtifact;
-    private String tapReportFilePath;
-    private String pdfReportFilePath;
-    private String junitReportFilePath;
-    private String coberturaReportFilePath;
-    private String stmResultsFilePath;
-    private String modelCoverageFilePath;
+    private Artifact tapArtifact = new NullArtifact();
+    private Artifact junitArtifact = new NullArtifact();
+    private Artifact coberturaArtifact = new NullArtifact();
+    private Artifact stmResultsArtifact = new NullArtifact();
+    private Artifact modelCoverageArtifact = new NullArtifact();
+    private Artifact pdfReportArtifact = new NullArtifact();
    
-
     @DataBoundConstructor
     public RunMatlabTestsBuilder() {
 
@@ -60,87 +54,81 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
 
     @DataBoundSetter
-    public void setTapArtifact(TapArtifact tapArtifact) {
+    public void setTapArtifact(Artifact tapArtifact) {
         this.tapArtifact = tapArtifact;
-        this.tapReportFilePath = this.tapArtifact.getTapReportFilePath();
     } 
    
     @DataBoundSetter
-    public void setJunitArtifact(JunitArtifact junitArtifact) {
+    public void setJunitArtifact(Artifact junitArtifact) {
         this.junitArtifact = junitArtifact;
-        this.junitReportFilePath = this.junitArtifact.getJunitReportFilePath();
     }
     
     @DataBoundSetter
-    public void setCoberturaArtifact(CoberturaArtifact coberturaArtifact) {
+    public void setCoberturaArtifact(Artifact coberturaArtifact) {
         this.coberturaArtifact = coberturaArtifact;
-        this.coberturaReportFilePath = this.coberturaArtifact.getCoberturaReportFilePath();
     }
     
     @DataBoundSetter
-    public void setStmResultsArtifact(StmResultsArtifact stmResultsArtifact) {
+    public void setStmResultsArtifact(Artifact stmResultsArtifact) {
         this.stmResultsArtifact = stmResultsArtifact;
-        this.stmResultsFilePath = this.stmResultsArtifact.getStmResultsFilePath();
     }
     
     @DataBoundSetter
-    public void setModelCoverageArtifact(ModelCovArtifact modelCoverageArtifact) {
+    public void setModelCoverageArtifact(Artifact modelCoverageArtifact) {
         this.modelCoverageArtifact = modelCoverageArtifact;
-        this.modelCoverageFilePath = this.modelCoverageArtifact.getModelCoverageFilePath();
     }   
 
     @DataBoundSetter
-    public void setPdfReportArtifact(PdfArtifact pdfReportArtifact) {
+    public void setPdfReportArtifact(Artifact pdfReportArtifact) {
         this.pdfReportArtifact = pdfReportArtifact;
-        this.pdfReportFilePath = this.pdfReportArtifact.getPdfReportFilePath();
     }
     
     public String getTapReportFilePath() {
-        return this.tapReportFilePath;
+        return this.getTapArtifact().getFilePath();
     }      
     
-    public TapArtifact getTapArtifact() {
+    public Artifact getTapArtifact() {
         return this.tapArtifact;
     }
         
-    public JunitArtifact getJunitArtifact() {
+    public Artifact getJunitArtifact() {
         return this.junitArtifact;
     }
     
     public String getJunitReportFilePath() {
-        return this.junitReportFilePath;
+        return this.getJunitArtifact().getFilePath();
     }
         
-    public CoberturaArtifact getCoberturaArtifact() {
+    public Artifact getCoberturaArtifact() {
         return this.coberturaArtifact;
     }
     
     public String getCoberturaReportFilePath() {
-        return this.coberturaReportFilePath;
+        return this.getCoberturaArtifact().getFilePath();
     }
           
-    public StmResultsArtifact getStmResultsArtifact() {
+    public Artifact getStmResultsArtifact() {
         return this.stmResultsArtifact;
     } 
     
     public String getStmResultsFilePath() {
-        return this.stmResultsFilePath;
+        return this.getStmResultsArtifact().getFilePath();
     }
        
-    public ModelCovArtifact getModelCoverageArtifact() {
+    public Artifact getModelCoverageArtifact() {
         return this.modelCoverageArtifact;
     }
     
     public String getModelCoverageFilePath() {
-        return modelCoverageFilePath;
+        return this.getModelCoverageArtifact().getFilePath();
     }
     
-    public PdfArtifact getPdfReportArtifact() {
+    public Artifact getPdfReportArtifact() {
         return this.pdfReportArtifact;
     }
     
     public String getPdfReportFilePath() {
-        return this.pdfReportFilePath;
+        return this.getPdfReportArtifact().getFilePath();
     }  
     
     private void setEnv(EnvVars env) {
@@ -242,7 +230,8 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
                         getModelCoverageArtifact()));
 
         for (Artifact artifact : artifactList) {
-            addInputArgs(artifact, inputArgs);
+            //addInputArgs(artifact, inputArgs);
+            artifact.addFilePathArgTo(inputArgs);
         }
 
         if (inputArgs.isEmpty()) {
@@ -252,11 +241,11 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         return String.join(",", inputArgs);
     }
 
-    public void addInputArgs(Artifact artifactType, List<String> inputArgs) {
+    /*public void addInputArgs(Artifact artifactType, List<String> inputArgs) {
         if (artifactType != null) {
             artifactType.addFilePathArgTo(inputArgs);
         }
-    }
+    }*/
     
     
     /*
@@ -269,11 +258,12 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
      * 7Csort:date/jenkinsci-dev/AFYHSG3NUEI/UsVJIKoE4B8J
      * 
      */
-    public static class PdfArtifact implements Artifact {
+    public static class PdfArtifact extends Artifact {
         private String pdfReportFilePath;
 
         @DataBoundConstructor
         public PdfArtifact() {
+           
 
         }
 
@@ -291,13 +281,25 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             inputArgs.add(MatlabBuilderConstants.PDF_REPORT_PATH + "," + "'"
                     + getPdfReportFilePath() + "'");
         }
+
+        @Override
+        public String getFilePath() {
+            return getPdfReportFilePath();
+        }
+
+        
+        public boolean getDefault() {
+            
+            return true;
+        }
     }
 
-    public static class TapArtifact implements Artifact {
+    public static class TapArtifact extends Artifact {
         private String tapReportFilePath;
 
         @DataBoundConstructor
         public TapArtifact() {
+            
 
         }
 
@@ -315,13 +317,24 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             inputArgs.add(MatlabBuilderConstants.TAP_RESULTS_PATH + "," + "'"
                     + getTapReportFilePath() + "'");
         }
+
+        @Override
+        public String getFilePath() {
+            return getTapReportFilePath();
+        }
+
+        
+        public boolean getDefault() {
+            return true;
+        }
     }
 
-    public static class JunitArtifact implements Artifact {
+    public static class JunitArtifact extends Artifact {
         private String junitReportFilePath;
 
         @DataBoundConstructor
         public JunitArtifact() {
+            
 
         }
 
@@ -339,13 +352,24 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             inputArgs.add(MatlabBuilderConstants.JUNIT_RESULTS_PATH + "," + "'"
                     + getJunitReportFilePath() + "'");
         }
+
+        @Override
+        public String getFilePath() {
+            return getJunitReportFilePath();
+        }
+
+        
+        public boolean getDefault() {
+            return true;
+        }
     }
 
-    public static class CoberturaArtifact implements Artifact {
+    public static class CoberturaArtifact extends Artifact {
         private String coberturaReportFilePath;
 
         @DataBoundConstructor
         public CoberturaArtifact() {
+            
 
         }
 
@@ -363,13 +387,24 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             inputArgs.add(MatlabBuilderConstants.COBERTURA_CODE_COVERAGE_PATH + "," + "'"
                     + getCoberturaReportFilePath() + "'");
         }
+
+        @Override
+        public String getFilePath() {
+            return getCoberturaReportFilePath();
+        }
+
+        
+        public boolean getDefault() {
+            return true;
+        }
     }
 
-    public static class StmResultsArtifact implements Artifact{
+    public static class StmResultsArtifact extends Artifact {
         private String stmResultsFilePath;
 
         @DataBoundConstructor
         public StmResultsArtifact() {
+            
 
         }
 
@@ -387,13 +422,24 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             inputArgs.add(MatlabBuilderConstants.STM_RESULTS_PATH + "," + "'"
                     + getStmResultsFilePath() + "'");
         }
+
+        @Override
+        public String getFilePath() {
+            return getStmResultsFilePath();
+        }
+
+        
+        public boolean getDefault() {
+            return true;
+        }
     }
 
-    public static class ModelCovArtifact implements Artifact {
+    public static class ModelCovArtifact extends Artifact {
         private String modelCoverageFilePath;
 
         @DataBoundConstructor
         public ModelCovArtifact() {
+            
 
         }
 
@@ -411,10 +457,63 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             inputArgs.add(MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE_PATH + "," + "'"
                     + getModelCoverageFilePath() + "'");
         }
+
+        @Override
+        public String getFilePath() {
+            
+            return getModelCoverageFilePath();
+        }
+
+        @Override
+        public boolean getDefault() {
+            return true;
+        }
     }
     
-    public interface Artifact {
-        public void addFilePathArgTo(List<String> inputArgs);
+    public static class NullArtifact extends Artifact {
+        
+        @DataBoundConstructor
+        public NullArtifact() {         
+  
+        }
+
+        @Override
+        public void addFilePathArgTo(List<String> inputArgs) {
+            
+        }
+        
+        
+        public boolean getDefault() {
+            return false;
+        }
+
+        @Override
+        public String getFilePath() {
+            return null;
+        }
+        
     }
+   
     
+    public static class Artifact {
+      
+        @DataBoundConstructor
+        public Artifact() {
+            
+        }
+        
+        
+      
+        public void addFilePathArgTo(List<String> inputArgs) {
+            
+        }
+        
+        public String getFilePath() {
+            return null;
+        }
+        
+        public boolean getDefault() {
+            return false;
+        }
+    } 
 }

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -43,11 +43,18 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
     private int buildResult;
     private EnvVars env;
     private boolean tapChkBx;
+    private String tapChkBxFilePath;
     private boolean junitChkBx;
+    private String junitChkBxFilePath;
     private boolean coberturaChkBx;
+    private String coberturaChkBxFilePath;
     private boolean stmResultsChkBx;
+    private String stmResultsChkBxFilePath;
     private boolean modelCoverageChkBx;
+    private String modelCoverageChkBxFilePath;
     private boolean pdfReportChkBx;
+    private String pdfReportFilePath;
+    private List<String> inputArgs = new ArrayList<String>();
 
     @DataBoundConstructor
     public RunMatlabTestsBuilder() {
@@ -63,54 +70,109 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
     public void setTapChkBx(boolean tapChkBx) {
         this.tapChkBx = tapChkBx;
     }
+    
+    @DataBoundSetter
+    public void setTapChkBxFilePath(String tapChkBxFilePath) {
+        this.tapChkBxFilePath = tapChkBxFilePath;
+    }
 
     @DataBoundSetter
     public void setJunitChkBx(boolean junitChkBx) {
         this.junitChkBx = junitChkBx;
+    }
+    
+    @DataBoundSetter
+    public void setJunitChkBxFilePath(String junitChkBxFilePath) {
+        this.junitChkBxFilePath = junitChkBxFilePath;
     }
 
     @DataBoundSetter
     public void setCoberturaChkBx(boolean coberturaChkBx) {
         this.coberturaChkBx = coberturaChkBx;
     }
+    
+    @DataBoundSetter
+    public void setCoberturaChkBxFilePath(String coberturaChkBxFilePath) {
+        this.coberturaChkBxFilePath = coberturaChkBxFilePath;
+    }
 
     @DataBoundSetter
     public void setStmResultsChkBx(boolean stmResultsChkBx) {
         this.stmResultsChkBx = stmResultsChkBx;
+    }
+    
+    @DataBoundSetter
+    public void setStmResultsChkBxFilePath(String stmResultsChkBxFilePath) {
+        this.stmResultsChkBxFilePath = stmResultsChkBxFilePath;
     }
 
     @DataBoundSetter
     public void setModelCoverageChkBx(boolean modelCoverageChkBx) {
         this.modelCoverageChkBx = modelCoverageChkBx;
     }
+    
+    @DataBoundSetter
+    public void setModelCoverageChkBxFilePath(String modelCoverageChkBxFilePath) {
+        this.modelCoverageChkBxFilePath = modelCoverageChkBxFilePath;
+    }
 
     @DataBoundSetter
     public void setPdfReportChkBx(boolean pdfReportChkBx) {
         this.pdfReportChkBx = pdfReportChkBx;
     }
+    
+    @DataBoundSetter
+    public void setPdfReportFilePath(String pdfReportFilePath) {
+        this.pdfReportFilePath = pdfReportFilePath;
+    }
+
 
     public boolean getTapChkBx() {
         return tapChkBx;
+    }
+    
+    public String getTapChkBxFilePath() {
+        return tapChkBxFilePath;
     }
 
     public boolean getJunitChkBx() {
         return junitChkBx;
     }
+    
+    public String getJunitChkBxFilePath() {
+        return junitChkBxFilePath;
+    }
 
     public boolean getCoberturaChkBx() {
         return coberturaChkBx;
+    }
+    
+    public String getCoberturaChkBxFilePath() {
+        return coberturaChkBxFilePath;
     }
 
     public boolean getStmResultsChkBx() {
         return stmResultsChkBx;
     }
+    
+    public String getStmResultsChkBxFilePath() {
+        return stmResultsChkBxFilePath;
+    }
 
     public boolean getModelCoverageChkBx() {
         return modelCoverageChkBx;
     }
+    
+    public String getModelCoverageChkBxFilePath() {
+        return modelCoverageChkBxFilePath;
+    }
 
     public boolean getPdfReportChkBx() {
         return pdfReportChkBx;
+    }
+    
+    public String getPdfReportFilePath() {
+        return this.pdfReportFilePath;
     }
 
     private void setEnv(EnvVars env) {
@@ -291,7 +353,7 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
             // Copy MATLAB scratch file into the workspace.
             FilePath targetWorkspace = new FilePath(launcher.getChannel(), workspace.getRemote());
-            copyFileInWorkspace(MatlabBuilderConstants.MATLAB_RUNNER_RESOURCE,
+            copyFileInWorkspace(MatlabBuilderConstants.MATLAB_TESTS_RUNNER_RESOURCE,
                     MatlabBuilderConstants.MATLAB_TESTS_RUNNER_TARGET_FILE, targetWorkspace);
             return matlabLauncher.join();
         } catch (Exception e) {
@@ -316,19 +378,40 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
     // Concatenate the input arguments
     private String getInputArguments() {
-        final String pdfReport = MatlabBuilderConstants.PDF_REPORT + "," + this.getPdfReportChkBx();
-        final String tapResults = MatlabBuilderConstants.TAP_RESULTS + "," + this.getTapChkBx();
-        final String junitResults =
-                MatlabBuilderConstants.JUNIT_RESULTS + "," + this.getJunitChkBx();
-        final String stmResults =
-                MatlabBuilderConstants.STM_RESULTS + "," + this.getStmResultsChkBx();
-        final String coberturaCodeCoverage =
-                MatlabBuilderConstants.COBERTURA_CODE_COVERAGE + "," + this.getCoberturaChkBx();
-        final String coberturaModelCoverage = MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE + ","
-                + this.getModelCoverageChkBx();
-        final String inputArgsToMatlabFcn = pdfReport + "," + tapResults + "," + junitResults + ","
-                + stmResults + "," + coberturaCodeCoverage + "," + coberturaModelCoverage;
 
-        return inputArgsToMatlabFcn;
+        addInputArgs(MatlabBuilderConstants.PDF_REPORT, getPdfReportChkBx(),
+                MatlabBuilderConstants.PDF_REPORT_PATH, getPdfReportFilePath());
+
+        addInputArgs(MatlabBuilderConstants.TAP_RESULTS, getTapChkBx(),
+                MatlabBuilderConstants.TAP_RESULTS_PATH, getTapChkBxFilePath());
+
+        addInputArgs(MatlabBuilderConstants.JUNIT_RESULTS, getJunitChkBx(),
+                MatlabBuilderConstants.JUNIT_RESULTS_PATH, getJunitChkBxFilePath());
+
+        addInputArgs(MatlabBuilderConstants.STM_RESULTS, getStmResultsChkBx(),
+                MatlabBuilderConstants.STM_RESULTS_PATH, getStmResultsChkBxFilePath());
+
+        addInputArgs(MatlabBuilderConstants.COBERTURA_CODE_COVERAGE, getCoberturaChkBx(),
+                MatlabBuilderConstants.COBERTURA_CODE_COVERAGE_PATH, getCoberturaChkBxFilePath());
+
+        addInputArgs(MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE, getModelCoverageChkBx(),
+                MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE_PATH,
+                getModelCoverageChkBxFilePath());
+
+        if (inputArgs.isEmpty()) {
+            return "";
+        }
+
+        return String.join(",", inputArgs);
+    }
+
+    private void addInputArgs(String chkbxName, boolean chkBxValue, String reportName,
+            String reportPath) {
+        if (chkBxValue) {
+            inputArgs.add(chkbxName + "," + chkBxValue);
+            if (!reportPath.isEmpty()) {
+                inputArgs.add(reportName + "," + "'" + reportPath + "'");
+            }
+        }
     }
 }

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -35,12 +35,12 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
     private int buildResult;
     private EnvVars env;
-    private TapChkBx tapChkBx;
-    private JunitChkBx junitChkBx;   
-    private CoberturaChkBx coberturaChkBx;
-    private StmResultsChkBx stmResultsChkBx; 
-    private ModelCovChkBx modelCoverageChkBx; 
-    private PdfChkBx pdfReportChkBx;
+    private TapArtifact tapArtifact;
+    private JunitArtifact junitArtifact;   
+    private CoberturaArtifact coberturaArtifact;
+    private StmResultsArtifact stmResultsArtifact; 
+    private ModelCovArtifact modelCoverageArtifact; 
+    private PdfArtifact pdfReportArtifact;
     private String tapReportFilePath;
     private String pdfReportFilePath;
     private String junitReportFilePath;
@@ -60,123 +60,83 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
 
     @DataBoundSetter
-    public void setTapChkBx(TapChkBx tapChkBx) {
-        this.tapChkBx = tapChkBx;
-        this.tapReportFilePath = this.tapChkBx.getTapReportFilePath();
+    public void setTapArtifact(TapArtifact tapArtifact) {
+        this.tapArtifact = tapArtifact;
+        this.tapReportFilePath = this.tapArtifact.getTapReportFilePath();
     } 
    
     @DataBoundSetter
-    public void setJunitChkBx(JunitChkBx junitChkBx) {
-        this.junitChkBx = junitChkBx;
-        this.junitReportFilePath = this.junitChkBx.getJunitReportFilePath();
+    public void setJunitArtifact(JunitArtifact junitArtifact) {
+        this.junitArtifact = junitArtifact;
+        this.junitReportFilePath = this.junitArtifact.getJunitReportFilePath();
     }
     
     @DataBoundSetter
-    public void setCoberturaChkBx(CoberturaChkBx coberturaChkBx) {
-        this.coberturaChkBx = coberturaChkBx;
-        this.coberturaReportFilePath = this.coberturaChkBx.getCoberturaReportFilePath();
+    public void setCoberturaArtifact(CoberturaArtifact coberturaArtifact) {
+        this.coberturaArtifact = coberturaArtifact;
+        this.coberturaReportFilePath = this.coberturaArtifact.getCoberturaReportFilePath();
     }
     
     @DataBoundSetter
-    public void setStmResultsChkBx(StmResultsChkBx stmResultsChkBx) {
-        this.stmResultsChkBx = stmResultsChkBx;
-        this.stmResultsFilePath = this.stmResultsChkBx.getStmResultsFilePath();
+    public void setStmResultsArtifact(StmResultsArtifact stmResultsArtifact) {
+        this.stmResultsArtifact = stmResultsArtifact;
+        this.stmResultsFilePath = this.stmResultsArtifact.getStmResultsFilePath();
     }
     
     @DataBoundSetter
-    public void setModelCoverageChkBx(ModelCovChkBx modelCoverageChkBx) {
-        this.modelCoverageChkBx = modelCoverageChkBx;
-        this.modelCoverageFilePath = this.modelCoverageChkBx.getModelCoverageFilePath();
+    public void setModelCoverageArtifact(ModelCovArtifact modelCoverageArtifact) {
+        this.modelCoverageArtifact = modelCoverageArtifact;
+        this.modelCoverageFilePath = this.modelCoverageArtifact.getModelCoverageFilePath();
     }   
 
     @DataBoundSetter
-    public void setPdfReportChkBx(PdfChkBx pdfReportChkBx) {
-        this.pdfReportChkBx = pdfReportChkBx;
-        this.pdfReportFilePath = this.pdfReportChkBx.getPdfReportFilePath();
+    public void setPdfReportArtifact(PdfArtifact pdfReportArtifact) {
+        this.pdfReportArtifact = pdfReportArtifact;
+        this.pdfReportFilePath = this.pdfReportArtifact.getPdfReportFilePath();
     }
     
     public String getTapReportFilePath() {
         return this.tapReportFilePath;
     }      
-    public boolean getIsPdfChecked() {
-        if(this.pdfReportChkBx != null) {
-            return true;
-        }
-        return false;
-    }
-    public TapChkBx getTapChkBx() {
-        return this.tapChkBx;
-    }
     
-    public boolean getIsTapChecked() {
-        if(this.tapChkBx != null) {
-            return true;
-        }
-        return false;
+    public TapArtifact getTapArtifact() {
+        return this.tapArtifact;
     }
-    
-    public JunitChkBx getJunitChkBx() {
-        return this.junitChkBx;
+        
+    public JunitArtifact getJunitArtifact() {
+        return this.junitArtifact;
     }
     
     public String getJunitReportFilePath() {
         return this.junitReportFilePath;
     }
-    
-    public boolean getIsJunitChecked() {
-        if(this.junitChkBx != null) {
-            return true;
-        }
-        return false;
-    }
-    
-    public CoberturaChkBx getCoberturaChkBx() {
-        return this.coberturaChkBx;
+        
+    public CoberturaArtifact getCoberturaArtifact() {
+        return this.coberturaArtifact;
     }
     
     public String getCoberturaReportFilePath() {
         return this.coberturaReportFilePath;
     }
-    
-    public boolean getIsCoberturaChecked() {
-        if(this.coberturaChkBx != null) {
-            return true;
-        }
-        return false;
-    }
-      
-    public StmResultsChkBx getStmResultsChkBx() {
-        return this.stmResultsChkBx;
+          
+    public StmResultsArtifact getStmResultsArtifact() {
+        return this.stmResultsArtifact;
     } 
     
     public String getStmResultsFilePath() {
         return this.stmResultsFilePath;
     }
-    
-    public boolean getIsStmChecked() {
-        if(this.stmResultsChkBx != null) {
-            return true;
-        }
-        return false;
-    }
-   
-    public ModelCovChkBx getModelCoverageChkBx() {
-        return this.modelCoverageChkBx;
+       
+    public ModelCovArtifact getModelCoverageArtifact() {
+        return this.modelCoverageArtifact;
     }
     
     public String getModelCoverageFilePath() {
         return modelCoverageFilePath;
     }
     
-    public boolean getIsModelCovChecked() {
-        if(this.modelCoverageChkBx != null) {
-            return true;
-        }
-        return false;
-    }
-    
-    public PdfChkBx getPdfReportChkBx() {
-        return this.pdfReportChkBx;
+    public PdfArtifact getPdfReportArtifact() {
+        return this.pdfReportArtifact;
     }
     
     public String getPdfReportFilePath() {
@@ -274,14 +234,30 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
     // Concatenate the input arguments
     private String getInputArguments() {
-        addInputArgs(MatlabBuilderConstants.PDF_REPORT_PATH, getPdfReportFilePath());
-        addInputArgs(MatlabBuilderConstants.TAP_RESULTS_PATH, getTapReportFilePath());
-        addInputArgs(MatlabBuilderConstants.JUNIT_RESULTS_PATH, getJunitReportFilePath());
-        addInputArgs(MatlabBuilderConstants.STM_RESULTS_PATH, getStmResultsFilePath());
-        addInputArgs(MatlabBuilderConstants.COBERTURA_CODE_COVERAGE_PATH,
-                getCoberturaReportFilePath());
-        addInputArgs(MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE_PATH,
-                getModelCoverageFilePath());
+
+        if (getPdfReportArtifact() != null) {
+            getPdfReportArtifact().addFilePathArgTo(inputArgs);
+        }
+
+        if (getTapArtifact() != null) {
+            getTapArtifact().addFilePathArgTo(inputArgs);
+        }
+
+        if (getJunitArtifact() != null) {
+            getJunitArtifact().addFilePathArgTo(inputArgs);
+        }
+
+        if (getStmResultsArtifact() != null) {
+            getStmResultsArtifact().addFilePathArgTo(inputArgs);
+        }
+
+        if (getCoberturaArtifact() != null) {
+            getCoberturaArtifact().addFilePathArgTo(inputArgs);
+        }
+
+        if (getModelCoverageArtifact() != null) {
+            getModelCoverageArtifact().addFilePathArgTo(inputArgs);
+        }
 
         if (inputArgs.isEmpty()) {
             return "";
@@ -289,12 +265,7 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
         return String.join(",", inputArgs);
     }
-    
-    private void addInputArgs(String reportName, String reportPath) {
-        if (reportPath != null) {
-            inputArgs.add(reportName + "," + "'" + reportPath + "'");
-        }
-    }
+
 
     /*
      * Classes for each optional block in jelly file.This is restriction from Stapler architecture
@@ -306,12 +277,12 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
      * 7Csort:date/jenkinsci-dev/AFYHSG3NUEI/UsVJIKoE4B8J
      * 
      */
-    public static class PdfChkBx {
+    public static class PdfArtifact {
         private String pdfReportFilePath;
 
         @DataBoundConstructor
-        public PdfChkBx() {
-            
+        public PdfArtifact() {
+
         }
 
         @DataBoundSetter
@@ -322,13 +293,18 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getPdfReportFilePath() {
             return this.pdfReportFilePath;
         }
+
+        public void addFilePathArgTo(List<String> inputArgs) {
+            inputArgs.add(MatlabBuilderConstants.PDF_REPORT_PATH + "," + "'"
+                    + getPdfReportFilePath() + "'");
+        }
     }
 
-    public static class TapChkBx {
+    public static class TapArtifact {
         private String tapReportFilePath;
 
         @DataBoundConstructor
-        public TapChkBx() {
+        public TapArtifact() {
 
         }
 
@@ -340,13 +316,18 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getTapReportFilePath() {
             return tapReportFilePath;
         }
+
+        public void addFilePathArgTo(List<String> inputArgs) {
+            inputArgs.add(MatlabBuilderConstants.TAP_RESULTS_PATH + "," + "'"
+                    + getTapReportFilePath() + "'");
+        }
     }
 
-    public static class JunitChkBx {
+    public static class JunitArtifact {
         private String junitReportFilePath;
 
         @DataBoundConstructor
-        public JunitChkBx() {
+        public JunitArtifact() {
 
         }
 
@@ -358,13 +339,18 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getJunitReportFilePath() {
             return this.junitReportFilePath;
         }
+
+        public void addFilePathArgTo(List<String> inputArgs) {
+            inputArgs.add(MatlabBuilderConstants.JUNIT_RESULTS_PATH + "," + "'"
+                    + getJunitReportFilePath() + "'");
+        }
     }
 
-    public static class CoberturaChkBx {
+    public static class CoberturaArtifact {
         private String coberturaReportFilePath;
 
         @DataBoundConstructor
-        public CoberturaChkBx() {
+        public CoberturaArtifact() {
 
         }
 
@@ -376,13 +362,18 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getCoberturaReportFilePath() {
             return this.coberturaReportFilePath;
         }
+
+        public void addFilePathArgTo(List<String> inputArgs) {
+            inputArgs.add(MatlabBuilderConstants.COBERTURA_CODE_COVERAGE_PATH + "," + "'"
+                    + getCoberturaReportFilePath() + "'");
+        }
     }
 
-    public static class StmResultsChkBx {
+    public static class StmResultsArtifact {
         private String stmResultsFilePath;
 
         @DataBoundConstructor
-        public StmResultsChkBx() {
+        public StmResultsArtifact() {
 
         }
 
@@ -394,13 +385,18 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getStmResultsFilePath() {
             return stmResultsFilePath;
         }
+
+        public void addFilePathArgTo(List<String> inputArgs) {
+            inputArgs.add(MatlabBuilderConstants.STM_RESULTS_PATH + "," + "'"
+                    + getStmResultsFilePath() + "'");
+        }
     }
 
-    public static class ModelCovChkBx {
+    public static class ModelCovArtifact {
         private String modelCoverageFilePath;
 
         @DataBoundConstructor
-        public ModelCovChkBx() {
+        public ModelCovArtifact() {
 
         }
 
@@ -412,6 +408,10 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getModelCoverageFilePath() {
             return modelCoverageFilePath;
         }
+
+        public void addFilePathArgTo(List<String> inputArgs) {
+            inputArgs.add(MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE_PATH + "," + "'"
+                    + getModelCoverageFilePath() + "'");
+        }
     }
-    
 }

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -10,6 +10,7 @@ package com.mathworks.ci;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.FilenameUtils;
@@ -48,7 +49,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
     private String stmResultsFilePath;
     private String modelCoverageFilePath;
    
-    private List<String> inputArgs = new ArrayList<String>();
 
     @DataBoundConstructor
     public RunMatlabTestsBuilder() {
@@ -235,28 +235,14 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
     // Concatenate the input arguments
     private String getInputArguments() {
 
-        if (getPdfReportArtifact() != null) {
-            getPdfReportArtifact().addFilePathArgTo(inputArgs);
-        }
+        final List<String> inputArgs = new ArrayList<String>();
+        final List<Artifact> artifactList =
+                new ArrayList<Artifact>(Arrays.asList(getPdfReportArtifact(), getTapArtifact(),
+                        getJunitArtifact(), getStmResultsArtifact(), getCoberturaArtifact(),
+                        getModelCoverageArtifact()));
 
-        if (getTapArtifact() != null) {
-            getTapArtifact().addFilePathArgTo(inputArgs);
-        }
-
-        if (getJunitArtifact() != null) {
-            getJunitArtifact().addFilePathArgTo(inputArgs);
-        }
-
-        if (getStmResultsArtifact() != null) {
-            getStmResultsArtifact().addFilePathArgTo(inputArgs);
-        }
-
-        if (getCoberturaArtifact() != null) {
-            getCoberturaArtifact().addFilePathArgTo(inputArgs);
-        }
-
-        if (getModelCoverageArtifact() != null) {
-            getModelCoverageArtifact().addFilePathArgTo(inputArgs);
+        for (Artifact artifact : artifactList) {
+            addInputArgs(artifact, inputArgs);
         }
 
         if (inputArgs.isEmpty()) {
@@ -266,7 +252,13 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         return String.join(",", inputArgs);
     }
 
-
+    public void addInputArgs(Artifact artifactType, List<String> inputArgs) {
+        if (artifactType != null) {
+            artifactType.addFilePathArgTo(inputArgs);
+        }
+    }
+    
+    
     /*
      * Classes for each optional block in jelly file.This is restriction from Stapler architecture
      * when we use <f:optionalBlock> as it creates a object for each block in JSON. This could be
@@ -277,7 +269,7 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
      * 7Csort:date/jenkinsci-dev/AFYHSG3NUEI/UsVJIKoE4B8J
      * 
      */
-    public static class PdfArtifact {
+    public static class PdfArtifact implements Artifact {
         private String pdfReportFilePath;
 
         @DataBoundConstructor
@@ -293,14 +285,15 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getPdfReportFilePath() {
             return this.pdfReportFilePath;
         }
-
+        
+        @Override
         public void addFilePathArgTo(List<String> inputArgs) {
             inputArgs.add(MatlabBuilderConstants.PDF_REPORT_PATH + "," + "'"
                     + getPdfReportFilePath() + "'");
         }
     }
 
-    public static class TapArtifact {
+    public static class TapArtifact implements Artifact {
         private String tapReportFilePath;
 
         @DataBoundConstructor
@@ -317,13 +310,14 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             return tapReportFilePath;
         }
 
+        @Override
         public void addFilePathArgTo(List<String> inputArgs) {
             inputArgs.add(MatlabBuilderConstants.TAP_RESULTS_PATH + "," + "'"
                     + getTapReportFilePath() + "'");
         }
     }
 
-    public static class JunitArtifact {
+    public static class JunitArtifact implements Artifact {
         private String junitReportFilePath;
 
         @DataBoundConstructor
@@ -340,13 +334,14 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             return this.junitReportFilePath;
         }
 
+        @Override
         public void addFilePathArgTo(List<String> inputArgs) {
             inputArgs.add(MatlabBuilderConstants.JUNIT_RESULTS_PATH + "," + "'"
                     + getJunitReportFilePath() + "'");
         }
     }
 
-    public static class CoberturaArtifact {
+    public static class CoberturaArtifact implements Artifact {
         private String coberturaReportFilePath;
 
         @DataBoundConstructor
@@ -363,13 +358,14 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             return this.coberturaReportFilePath;
         }
 
+        @Override
         public void addFilePathArgTo(List<String> inputArgs) {
             inputArgs.add(MatlabBuilderConstants.COBERTURA_CODE_COVERAGE_PATH + "," + "'"
                     + getCoberturaReportFilePath() + "'");
         }
     }
 
-    public static class StmResultsArtifact {
+    public static class StmResultsArtifact implements Artifact{
         private String stmResultsFilePath;
 
         @DataBoundConstructor
@@ -386,13 +382,14 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             return stmResultsFilePath;
         }
 
+        @Override
         public void addFilePathArgTo(List<String> inputArgs) {
             inputArgs.add(MatlabBuilderConstants.STM_RESULTS_PATH + "," + "'"
                     + getStmResultsFilePath() + "'");
         }
     }
 
-    public static class ModelCovArtifact {
+    public static class ModelCovArtifact implements Artifact {
         private String modelCoverageFilePath;
 
         @DataBoundConstructor
@@ -409,9 +406,15 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             return modelCoverageFilePath;
         }
 
+        @Override
         public void addFilePathArgTo(List<String> inputArgs) {
             inputArgs.add(MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE_PATH + "," + "'"
                     + getModelCoverageFilePath() + "'");
         }
     }
+    
+    public interface Artifact {
+        public void addFilePathArgTo(List<String> inputArgs);
+    }
+    
 }

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -1,5 +1,13 @@
 package com.mathworks.ci;
 
+/** 
+ * Copyright 2019-2020 The MathWorks, Inc.  
+ *  
+ * MATLAB test run builder used to run all MATLAB & Simulink tests automatically and generate   
+ * selected test artifacts. 
+ *  
+ */
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -142,7 +150,7 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
     } 
     
     public String getStmResultsFilePath() {
-        return stmResultsFilePath;
+        return this.stmResultsFilePath;
     }
     
     public boolean getIsStmChecked() {

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -42,23 +42,23 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
     private int buildResult;
     private EnvVars env;
-    private boolean tapChkBx;
-    private String tapChkBxFilePath;
-    private boolean junitChkBx;
-    private String junitChkBxFilePath;
-    private boolean coberturaChkBx;
-    private String coberturaChkBxFilePath;
-    private boolean stmResultsChkBx;
-    private String stmResultsChkBxFilePath;
-    private boolean modelCoverageChkBx;
-    private String modelCoverageChkBxFilePath;
-    private boolean pdfReportChkBx;
+    private TapChkBx tapChkBx;
+    private JunitChkBx junitChkBx;   
+    private CoberturaChkBx coberturaChkBx;
+    private StmResultsChkBx stmResultsChkBx; 
+    private ModelCovChkBx modelCoverageChkBx; 
+    private PdfChkBx pdfReportChkBx;
+    private String tapReportFilePath;
     private String pdfReportFilePath;
+    private String junitReportFilePath;
+    private String coberturaReportFilePath;
+    private String stmResultsFilePath;
+    private String modelCoverageFilePath;
+   
     private List<String> inputArgs = new ArrayList<String>();
 
     @DataBoundConstructor
     public RunMatlabTestsBuilder() {
-
 
     }
 
@@ -67,114 +67,129 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
 
     @DataBoundSetter
-    public void setTapChkBx(boolean tapChkBx) {
+    public void setTapChkBx(TapChkBx tapChkBx) {
         this.tapChkBx = tapChkBx;
-    }
-    
+        this.tapReportFilePath = this.tapChkBx.getTapReportFilePath();
+    } 
+   
     @DataBoundSetter
-    public void setTapChkBxFilePath(String tapChkBxFilePath) {
-        this.tapChkBxFilePath = tapChkBxFilePath;
-    }
-
-    @DataBoundSetter
-    public void setJunitChkBx(boolean junitChkBx) {
+    public void setJunitChkBx(JunitChkBx junitChkBx) {
         this.junitChkBx = junitChkBx;
+        this.junitReportFilePath = this.junitChkBx.getJunitReportFilePath();
     }
     
     @DataBoundSetter
-    public void setJunitChkBxFilePath(String junitChkBxFilePath) {
-        this.junitChkBxFilePath = junitChkBxFilePath;
-    }
-
-    @DataBoundSetter
-    public void setCoberturaChkBx(boolean coberturaChkBx) {
+    public void setCoberturaChkBx(CoberturaChkBx coberturaChkBx) {
         this.coberturaChkBx = coberturaChkBx;
+        this.coberturaReportFilePath = this.coberturaChkBx.getCoberturaReportFilePath();
     }
     
     @DataBoundSetter
-    public void setCoberturaChkBxFilePath(String coberturaChkBxFilePath) {
-        this.coberturaChkBxFilePath = coberturaChkBxFilePath;
-    }
-
-    @DataBoundSetter
-    public void setStmResultsChkBx(boolean stmResultsChkBx) {
+    public void setStmResultsChkBx(StmResultsChkBx stmResultsChkBx) {
         this.stmResultsChkBx = stmResultsChkBx;
+        this.stmResultsFilePath = this.stmResultsChkBx.getStmResultsFilePath();
     }
     
     @DataBoundSetter
-    public void setStmResultsChkBxFilePath(String stmResultsChkBxFilePath) {
-        this.stmResultsChkBxFilePath = stmResultsChkBxFilePath;
-    }
-
-    @DataBoundSetter
-    public void setModelCoverageChkBx(boolean modelCoverageChkBx) {
+    public void setModelCoverageChkBx(ModelCovChkBx modelCoverageChkBx) {
         this.modelCoverageChkBx = modelCoverageChkBx;
-    }
-    
-    @DataBoundSetter
-    public void setModelCoverageChkBxFilePath(String modelCoverageChkBxFilePath) {
-        this.modelCoverageChkBxFilePath = modelCoverageChkBxFilePath;
-    }
+        this.modelCoverageFilePath = this.modelCoverageChkBx.getModelCoverageFilePath();
+    }   
 
     @DataBoundSetter
-    public void setPdfReportChkBx(boolean pdfReportChkBx) {
+    public void setPdfReportChkBx(PdfChkBx pdfReportChkBx) {
         this.pdfReportChkBx = pdfReportChkBx;
+        this.pdfReportFilePath = this.pdfReportChkBx.getPdfReportFilePath();
     }
     
-    @DataBoundSetter
-    public void setPdfReportFilePath(String pdfReportFilePath) {
-        this.pdfReportFilePath = pdfReportFilePath;
+    public String getTapReportFilePath() {
+        return this.tapReportFilePath;
+    }      
+    public boolean getIsPdfChecked() {
+        if(this.pdfReportChkBx != null) {
+            return true;
+        }
+        return false;
     }
-
-
-    public boolean getTapChkBx() {
-        return tapChkBx;
-    }
-    
-    public String getTapChkBxFilePath() {
-        return tapChkBxFilePath;
-    }
-
-    public boolean getJunitChkBx() {
-        return junitChkBx;
+    public TapChkBx getTapChkBx() {
+        return this.tapChkBx;
     }
     
-    public String getJunitChkBxFilePath() {
-        return junitChkBxFilePath;
-    }
-
-    public boolean getCoberturaChkBx() {
-        return coberturaChkBx;
-    }
-    
-    public String getCoberturaChkBxFilePath() {
-        return coberturaChkBxFilePath;
-    }
-
-    public boolean getStmResultsChkBx() {
-        return stmResultsChkBx;
+    public boolean getIsTapChecked() {
+        if(this.tapChkBx != null) {
+            return true;
+        }
+        return false;
     }
     
-    public String getStmResultsChkBxFilePath() {
-        return stmResultsChkBxFilePath;
-    }
-
-    public boolean getModelCoverageChkBx() {
-        return modelCoverageChkBx;
+    public JunitChkBx getJunitChkBx() {
+        return this.junitChkBx;
     }
     
-    public String getModelCoverageChkBxFilePath() {
-        return modelCoverageChkBxFilePath;
+    public String getJunitReportFilePath() {
+        return this.junitReportFilePath;
     }
-
-    public boolean getPdfReportChkBx() {
-        return pdfReportChkBx;
+    
+    public boolean getIsJunitChecked() {
+        if(this.junitChkBx != null) {
+            return true;
+        }
+        return false;
+    }
+    
+    public CoberturaChkBx getCoberturaChkBx() {
+        return this.coberturaChkBx;
+    }
+    
+    public String getCoberturaReportFilePath() {
+        return this.coberturaReportFilePath;
+    }
+    
+    public boolean getIsCoberturaChecked() {
+        if(this.coberturaChkBx != null) {
+            return true;
+        }
+        return false;
+    }
+      
+    public StmResultsChkBx getStmResultsChkBx() {
+        return this.stmResultsChkBx;
+    } 
+    
+    public String getStmResultsFilePath() {
+        return stmResultsFilePath;
+    }
+    
+    public boolean getIsStmChecked() {
+        if(this.stmResultsChkBx != null) {
+            return true;
+        }
+        return false;
+    }
+   
+    public ModelCovChkBx getModelCoverageChkBx() {
+        return this.modelCoverageChkBx;
+    }
+    
+    public String getModelCoverageFilePath() {
+        return modelCoverageFilePath;
+    }
+    
+    public boolean getIsModelCovChecked() {
+        if(this.modelCoverageChkBx != null) {
+            return true;
+        }
+        return false;
+    }
+    
+    public PdfChkBx getPdfReportChkBx() {
+        return this.pdfReportChkBx;
     }
     
     public String getPdfReportFilePath() {
         return this.pdfReportFilePath;
-    }
-
+    }  
+    
     private void setEnv(EnvVars env) {
         this.env = env;
     }
@@ -223,10 +238,10 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
 
 
-        public FormValidation doCheckCoberturaChkBx(@QueryParameter boolean coberturaChkBx) {
+        public FormValidation doCheckCoberturaChkBxFilePath(@QueryParameter String coberturaChkBxFilePath) {
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();
-            if (coberturaChkBx) {
+            if(!coberturaChkBxFilePath.isEmpty()) {
                 listOfCheckMethods.add(chkCoberturaSupport);
             }
             return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods, getMatlabRoot());
@@ -252,12 +267,12 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
             return FormValidation.ok();
         };
-
-        public FormValidation doCheckModelCoverageChkBx(
-                @QueryParameter boolean modelCoverageChkBx) {
+                
+        public FormValidation doCheckModelCoverageChkBxFilePath(
+                @QueryParameter String modelCoverageChkBxFilePath) {
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();
-            if (modelCoverageChkBx) {
+            if (!modelCoverageChkBxFilePath.isEmpty()) {
                 listOfCheckMethods.add(chkModelCoverageSupport);
             }
             return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods, getMatlabRoot());
@@ -284,10 +299,10 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             return FormValidation.ok();
         };
 
-        public FormValidation doCheckStmResultsChkBx(@QueryParameter boolean stmResultsChkBx) {
+        public FormValidation doCheckStmResultsChkBxFilePath(@QueryParameter String stmResultsChkBxFilePath) {
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();
-            if (stmResultsChkBx) {
+            if (!stmResultsChkBxFilePath.isEmpty()) {
                 listOfCheckMethods.add(chkSTMResultsSupport);
             }
             return FormValidationUtil.getFirstErrorOrWarning(listOfCheckMethods, getMatlabRoot());
@@ -378,25 +393,14 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
     // Concatenate the input arguments
     private String getInputArguments() {
-
-        addInputArgs(MatlabBuilderConstants.PDF_REPORT, getPdfReportChkBx(),
-                MatlabBuilderConstants.PDF_REPORT_PATH, getPdfReportFilePath());
-
-        addInputArgs(MatlabBuilderConstants.TAP_RESULTS, getTapChkBx(),
-                MatlabBuilderConstants.TAP_RESULTS_PATH, getTapChkBxFilePath());
-
-        addInputArgs(MatlabBuilderConstants.JUNIT_RESULTS, getJunitChkBx(),
-                MatlabBuilderConstants.JUNIT_RESULTS_PATH, getJunitChkBxFilePath());
-
-        addInputArgs(MatlabBuilderConstants.STM_RESULTS, getStmResultsChkBx(),
-                MatlabBuilderConstants.STM_RESULTS_PATH, getStmResultsChkBxFilePath());
-
-        addInputArgs(MatlabBuilderConstants.COBERTURA_CODE_COVERAGE, getCoberturaChkBx(),
-                MatlabBuilderConstants.COBERTURA_CODE_COVERAGE_PATH, getCoberturaChkBxFilePath());
-
-        addInputArgs(MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE, getModelCoverageChkBx(),
-                MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE_PATH,
-                getModelCoverageChkBxFilePath());
+        addInputArgs(MatlabBuilderConstants.PDF_REPORT_PATH, getPdfReportFilePath());
+        addInputArgs(MatlabBuilderConstants.TAP_RESULTS_PATH, getTapReportFilePath());
+        addInputArgs(MatlabBuilderConstants.JUNIT_RESULTS_PATH, getJunitReportFilePath());
+        addInputArgs(MatlabBuilderConstants.STM_RESULTS_PATH, getStmResultsFilePath());
+        addInputArgs(MatlabBuilderConstants.COBERTURA_CODE_COVERAGE_PATH,
+                getCoberturaReportFilePath());
+        addInputArgs(MatlabBuilderConstants.COBERTURA_MODEL_COVERAGE_PATH,
+                getModelCoverageFilePath());
 
         if (inputArgs.isEmpty()) {
             return "";
@@ -404,14 +408,129 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
         return String.join(",", inputArgs);
     }
-
-    private void addInputArgs(String chkbxName, boolean chkBxValue, String reportName,
-            String reportPath) {
-        if (chkBxValue) {
-            inputArgs.add(chkbxName + "," + chkBxValue);
-            if (!reportPath.isEmpty()) {
-                inputArgs.add(reportName + "," + "'" + reportPath + "'");
-            }
+    
+    private void addInputArgs(String reportName, String reportPath) {
+        if (reportPath != null) {
+            inputArgs.add(reportName + "," + "'" + reportPath + "'");
         }
     }
+
+    /*
+     * Classes for each optional block in jelly file.This is restriction from Stapler architecture
+     * when we use <f:optionalBlock> as it creates a object for each block in JSON. This could be
+     * simplified by using inline=true attribute of <f:optionalBlock> however it has some abrupt UI
+     * scrolling issue on click and also some esthetic issue like broken gray side bar appears.Some
+     * discussion about this on Jenkins forum
+     * https://groups.google.com/forum/#!searchin/jenkinsci-dev/OptionalBlock$20action$20class%
+     * 7Csort:date/jenkinsci-dev/AFYHSG3NUEI/UsVJIKoE4B8J
+     * 
+     */
+    public class PdfChkBx {
+        String pdfReportFilePath;
+
+        @DataBoundConstructor
+        public PdfChkBx() {
+            
+        }
+
+        @DataBoundSetter
+        public void setPdfReportFilePath(String pdfReportFilePath) {
+            this.pdfReportFilePath = pdfReportFilePath;
+        }
+
+        public String getPdfReportFilePath() {
+            return this.pdfReportFilePath;
+        }
+    }
+
+    public class TapChkBx {
+        String tapReportFilePath;
+
+        @DataBoundConstructor
+        public TapChkBx() {
+
+        }
+
+        @DataBoundSetter
+        public void setTapReportFilePath(String tapReportFilePath) {
+            this.tapReportFilePath = tapReportFilePath;
+        }
+
+        public String getTapReportFilePath() {
+            return tapReportFilePath;
+        }
+    }
+
+    public class JunitChkBx {
+        String junitReportFilePath;
+
+        @DataBoundConstructor
+        public JunitChkBx() {
+
+        }
+
+        @DataBoundSetter
+        public void setJunitReportFilePath(String junitReportFilePath) {
+            this.junitReportFilePath = junitReportFilePath;
+        }
+
+        public String getJunitReportFilePath() {
+            return this.junitReportFilePath;
+        }
+    }
+
+    public class CoberturaChkBx {
+        String coberturaReportFilePath;
+
+        @DataBoundConstructor
+        public CoberturaChkBx() {
+
+        }
+
+        @DataBoundSetter
+        public void setCoberturaReportFilePath(String coberturaReportFilePath) {
+            this.coberturaReportFilePath = coberturaReportFilePath;
+        }
+
+        public String getCoberturaReportFilePath() {
+            return this.coberturaReportFilePath;
+        }
+    }
+
+    public class StmResultsChkBx {
+        String stmResultsFilePath;
+
+        @DataBoundConstructor
+        public StmResultsChkBx() {
+
+        }
+
+        @DataBoundSetter
+        public void setStmResultsFilePath(String stmResultsFilePath) {
+            this.stmResultsFilePath = stmResultsFilePath;
+        }
+
+        public String getStmResultsFilePath() {
+            return stmResultsFilePath;
+        }
+    }
+
+    public class ModelCovChkBx {
+        String modelCoverageFilePath;
+
+        @DataBoundConstructor
+        public ModelCovChkBx() {
+
+        }
+
+        @DataBoundSetter
+        public void setModelCoverageFilePath(String modelCoverageFilePath) {
+            this.modelCoverageFilePath = modelCoverageFilePath;
+        }
+
+        public String getModelCoverageFilePath() {
+            return modelCoverageFilePath;
+        }
+    }
+    
 }

--- a/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsBuilder.java
@@ -18,7 +18,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
-import org.w3c.dom.views.AbstractView;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -54,32 +53,32 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
 
 
     @DataBoundSetter
-    public void setTapArtifact(Artifact tapArtifact) {
+    public void setTapArtifact(TapArtifact tapArtifact) {
         this.tapArtifact = tapArtifact;
     } 
    
     @DataBoundSetter
-    public void setJunitArtifact(Artifact junitArtifact) {
+    public void setJunitArtifact(JunitArtifact junitArtifact) {
         this.junitArtifact = junitArtifact;
     }
     
     @DataBoundSetter
-    public void setCoberturaArtifact(Artifact coberturaArtifact) {
+    public void setCoberturaArtifact(CoberturaArtifact coberturaArtifact) {
         this.coberturaArtifact = coberturaArtifact;
     }
     
     @DataBoundSetter
-    public void setStmResultsArtifact(Artifact stmResultsArtifact) {
+    public void setStmResultsArtifact(StmResultsArtifact stmResultsArtifact) {
         this.stmResultsArtifact = stmResultsArtifact;
     }
     
     @DataBoundSetter
-    public void setModelCoverageArtifact(Artifact modelCoverageArtifact) {
+    public void setModelCoverageArtifact(ModelCovArtifact modelCoverageArtifact) {
         this.modelCoverageArtifact = modelCoverageArtifact;
     }   
 
     @DataBoundSetter
-    public void setPdfReportArtifact(Artifact pdfReportArtifact) {
+    public void setPdfReportArtifact(PdfArtifact pdfReportArtifact) {
         this.pdfReportArtifact = pdfReportArtifact;
     }
     
@@ -230,23 +229,12 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
                         getModelCoverageArtifact()));
 
         for (Artifact artifact : artifactList) {
-            //addInputArgs(artifact, inputArgs);
             artifact.addFilePathArgTo(inputArgs);
-        }
-
-        if (inputArgs.isEmpty()) {
-            return "";
         }
 
         return String.join(",", inputArgs);
     }
 
-    /*public void addInputArgs(Artifact artifactType, List<String> inputArgs) {
-        if (artifactType != null) {
-            artifactType.addFilePathArgTo(inputArgs);
-        }
-    }*/
-    
     
     /*
      * Classes for each optional block in jelly file.This is restriction from Stapler architecture
@@ -264,7 +252,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         @DataBoundConstructor
         public PdfArtifact() {
            
-
         }
 
         @DataBoundSetter
@@ -286,12 +273,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getFilePath() {
             return getPdfReportFilePath();
         }
-
-        
-        public boolean getDefault() {
-            
-            return true;
-        }
     }
 
     public static class TapArtifact extends Artifact {
@@ -300,7 +281,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         @DataBoundConstructor
         public TapArtifact() {
             
-
         }
 
         @DataBoundSetter
@@ -322,11 +302,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getFilePath() {
             return getTapReportFilePath();
         }
-
-        
-        public boolean getDefault() {
-            return true;
-        }
     }
 
     public static class JunitArtifact extends Artifact {
@@ -335,7 +310,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         @DataBoundConstructor
         public JunitArtifact() {
             
-
         }
 
         @DataBoundSetter
@@ -357,11 +331,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getFilePath() {
             return getJunitReportFilePath();
         }
-
-        
-        public boolean getDefault() {
-            return true;
-        }
     }
 
     public static class CoberturaArtifact extends Artifact {
@@ -370,7 +339,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         @DataBoundConstructor
         public CoberturaArtifact() {
             
-
         }
 
         @DataBoundSetter
@@ -392,11 +360,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getFilePath() {
             return getCoberturaReportFilePath();
         }
-
-        
-        public boolean getDefault() {
-            return true;
-        }
     }
 
     public static class StmResultsArtifact extends Artifact {
@@ -405,7 +368,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         @DataBoundConstructor
         public StmResultsArtifact() {
             
-
         }
 
         @DataBoundSetter
@@ -427,11 +389,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         public String getFilePath() {
             return getStmResultsFilePath();
         }
-
-        
-        public boolean getDefault() {
-            return true;
-        }
     }
 
     public static class ModelCovArtifact extends Artifact {
@@ -440,7 +397,6 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
         @DataBoundConstructor
         public ModelCovArtifact() {
             
-
         }
 
         @DataBoundSetter
@@ -463,57 +419,39 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep, M
             
             return getModelCoverageFilePath();
         }
+    }
+    
+    public static class NullArtifact extends Artifact {
+
+        @DataBoundConstructor
+        public NullArtifact() {
+
+        }
 
         @Override
+        public void addFilePathArgTo(List<String> inputArgs) {
+
+        }
+
+        @Override
+        public boolean getDefault() {
+            return false;
+        }
+
+        @Override
+        public String getFilePath() {
+            return null;
+        }
+    }
+
+    
+    public static abstract class Artifact {
+        public abstract void addFilePathArgTo(List<String> inputArgs);
+
+        public abstract String getFilePath();
+
         public boolean getDefault() {
             return true;
         }
     }
-    
-    public static class NullArtifact extends Artifact {
-        
-        @DataBoundConstructor
-        public NullArtifact() {         
-  
-        }
-
-        @Override
-        public void addFilePathArgTo(List<String> inputArgs) {
-            
-        }
-        
-        
-        public boolean getDefault() {
-            return false;
-        }
-
-        @Override
-        public String getFilePath() {
-            return null;
-        }
-        
-    }
-   
-    
-    public static class Artifact {
-      
-        @DataBoundConstructor
-        public Artifact() {
-            
-        }
-        
-        
-      
-        public void addFilePathArgTo(List<String> inputArgs) {
-            
-        }
-        
-        public String getFilePath() {
-            return null;
-        }
-        
-        public boolean getDefault() {
-            return false;
-        }
-    } 
 }

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
@@ -2,25 +2,25 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     
 <f:section title="Generate Test Artifacts">
-    <f:optionalBlock name="pdfReportArtifact" field="pdfReportArtifact" title="PDF test report" checked="${instance.pdfReportArtifact.default}">
+    <f:optionalBlock name="pdfReportArtifact" field="pdfReportArtifact" title="PDF test report" checked="${instance.pdfReportArtifact.selected}">
   	 <f:entry field="pdfReportFilePath" title="File path: ">	
     	<f:textbox default="matlabTestArtifacts/testreport.pdf"/>
      </f:entry>
     </f:optionalBlock>
      
-    <f:optionalBlock name="tapArtifact" field="tapArtifact" title="TAP test results" checked="${instance.tapArtifact.default}">   	
+    <f:optionalBlock name="tapArtifact" field="tapArtifact" title="TAP test results" checked="${instance.tapArtifact.selected}">   	
      <f:entry field="tapReportFilePath" title="File path: ">	
     	<f:textbox default="matlabTestArtifacts/taptestresults.tap"/>
      </f:entry>
     </f:optionalBlock>
      
-    <f:optionalBlock name="junitArtifact" field="junitArtifact" title="JUnit-style test results" checked="${instance.junitArtifact.default}"> 	
+    <f:optionalBlock name="junitArtifact" field="junitArtifact" title="JUnit-style test results" checked="${instance.junitArtifact.selected}"> 	
   	  <f:entry field="junitReportFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/junittestresults.xml"/>
   	  </f:entry>      
     </f:optionalBlock>
     
-   <f:optionalBlock name="stmResultsArtifact" field="stmResultsArtifact" title="Simulink Test Manager results" checked="${instance.stmResultsArtifact.default}">  
+   <f:optionalBlock name="stmResultsArtifact" field="stmResultsArtifact" title="Simulink Test Manager results" checked="${instance.stmResultsArtifact.selected}">  
   	 <f:entry field="stmResultsFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/simulinktestresults.mldatx"/>
      </f:entry>   
@@ -29,13 +29,13 @@
 </f:section>
 
 <f:section title="Generate Coverage Artifacts">
-   <f:optionalBlock name="coberturaArtifact" field="coberturaArtifact" title="Cobertura code coverage" checked="${instance.coberturaArtifact.default}">
+   <f:optionalBlock name="coberturaArtifact" field="coberturaArtifact" title="Cobertura code coverage" checked="${instance.coberturaArtifact.selected}">
 	 <f:entry field="coberturaReportFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/cobertura.xml"/>
      </f:entry>
    </f:optionalBlock>
    
-   <f:optionalBlock name="modelCoverageArtifact" field="modelCoverageArtifact" title="Cobertura model coverage" checked="${instance.modelCoverageArtifact.default}">
+   <f:optionalBlock name="modelCoverageArtifact" field="modelCoverageArtifact" title="Cobertura model coverage" checked="${instance.modelCoverageArtifact.selected}">
   	  <f:entry field="modelCoverageFilePath" title="File path: ">
   	  <f:textbox default="matlabTestArtifacts/modelcoverage.xml"/>
   	  </f:entry>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
@@ -3,25 +3,25 @@
     
 <f:section title="Generate Test Artifacts">
     <f:optionalBlock name="pdfReportChkBx" field="pdfReportChkBx" title="PDF test report" checked="${instance.isPdfChecked}">
-  	 <f:entry field="pdfReportFilePath" title="File location ">	
+  	 <f:entry field="pdfReportFilePath" title="File path: ">	
     	<f:textbox default="matlabTestArtifacts/testreport.pdf"/>
      </f:entry>
     </f:optionalBlock>
      
     <f:optionalBlock name="tapChkBx" field="tapChkBx" title="TAP test results" checked="${instance.isTapChecked}">   	
-     <f:entry field="tapReportFilePath" title="File location ">	
+     <f:entry field="tapReportFilePath" title="File path: ">	
     	<f:textbox default="matlabTestArtifacts/taptestresults.tap"/>
      </f:entry>
     </f:optionalBlock>
      
     <f:optionalBlock name="junitChkBx" field="junitChkBx" title="JUnit-style test results" checked="${instance.isJunitChecked}"> 	
-  	  <f:entry field="junitReportFilePath" title="File location ">
+  	  <f:entry field="junitReportFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/junittestresults.xml"/>
   	  </f:entry>      
     </f:optionalBlock>
     
    <f:optionalBlock name="stmResultsChkBx" field="stmResultsChkBx" title="Simulink Test Manager results" checked="${instance.isStmChecked}">  
-  	 <f:entry field="stmResultsFilePath" title="File location ">
+  	 <f:entry field="stmResultsFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/simulinktestresults.mldatx"/>
      </f:entry>   
    </f:optionalBlock>
@@ -30,13 +30,13 @@
 
 <f:section title="Generate Coverage Artifacts">
    <f:optionalBlock name="coberturaChkBx" field="coberturaChkBx" title="Cobertura code coverage" checked="${instance.isCoberturaChecked}">
-	 <f:entry field="coberturaReportFilePath" title="File location ">
+	 <f:entry field="coberturaReportFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/cobertura.xml"/>
      </f:entry>
    </f:optionalBlock>
    
    <f:optionalBlock name="modelCoverageChkBx" field="modelCoverageChkBx" title="Cobertura model coverage" checked="${instance.isModelCovChecked}">
-  	  <f:entry field="modelCoverageFilePath" title="File location ">
+  	  <f:entry field="modelCoverageFilePath" title="File path: ">
   	  <f:textbox default="matlabTestArtifacts/modelcoverage.xml"/>
   	  </f:entry>
    </f:optionalBlock>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
@@ -2,42 +2,43 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     
 <f:section title="Generate Test Artifacts">
-    <f:optionalBlock name="pdfReportChkBx" title="PDF test report" checked="${instance.pdfReportChkBx}" inline="true">
+    <f:optionalBlock name="pdfReportChkBx" field="pdfReportChkBx" title="PDF test report" checked="${instance.isPdfChecked}">
   	 <f:entry field="pdfReportFilePath" title="Save PDF report at">	
     	<f:textbox default="matlabTestArtifacts/testreport.pdf"/>
      </f:entry>
     </f:optionalBlock>
-    
-    <f:optionalBlock name="tapChkBx" title="TAP test results" checked="${instance.tapChkBx}" inline="true">   	
+     
+    <f:optionalBlock name="tapChkBx" field="tapChkBx" title="TAP test results" checked="${instance.isTapChecked}">   	
      <f:entry field="tapChkBxFilePath" title="Save TAP report at">	
     	<f:textbox default="matlabTestArtifacts/taptestresults.tap"/>
      </f:entry>
     </f:optionalBlock>
      
-    <f:optionalBlock name="junitChkBx" title="JUnit-style test results" checked="${instance.junitChkBx}" inline="true"> 	
+    <f:optionalBlock name="junitChkBx" field="junitChkBx" title="JUnit-style test results" checked="${instance.isJunitChecked}"> 	
   	  <f:entry field="junitChkBxFilePath" title="Save JUnit-style report at">
     	<f:textbox default="matlabTestArtifacts/junittestresults.xml"/>
   	  </f:entry>      
     </f:optionalBlock>
     
-   <f:optionalBlock name="stmResultsChkBx" title="Simulink Test Manager results" checked="${instance.stmResultsChkBx}" inline="true">  
+   <f:optionalBlock name="stmResultsChkBx" field="stmResultsChkBx" title="Simulink Test Manager results" checked="${instance.isStmChecked}">  
   	 <f:entry field="stmResultsChkBxFilePath" title="Save Simulink Test Manager results at">
     	<f:textbox default="matlabTestArtifacts/simulinktestresults.mldatx"/>
      </f:entry>   
    </f:optionalBlock>
+  
 </f:section>
 
 <f:section title="Generate Coverage Artifacts">
-   <f:optionalBlock name="coberturaChkBx" title="Cobertura code coverage" checked="${instance.coberturaChkBx}" inline="true">
+   <f:optionalBlock name="coberturaChkBx" field="coberturaChkBx" title="Cobertura code coverage" checked="${instance.isCoberturaChecked}">
 	 <f:entry field="coberturaChkBxFilePath" title="Save Cobertura code coverage at">
     	<f:textbox default="matlabTestArtifacts/cobertura.xml"/>
      </f:entry>
    </f:optionalBlock>
    
-   <f:optionalBlock name="modelCoverageChkBx" title="Cobertura model coverage" checked="${instance.modelCoverageChkBx}" inline="true">
-  	  <f:entry field="modelCoverageChkBxFilePath" title="Save Cobertura model coverage at">
-    	<f:textbox default="matlabTestArtifacts/coberturamodelcoverage.xml"/>
-  	  </f:entry>  
+   <f:optionalBlock name="modelCoverageChkBx" field="modelCoverageChkBx" title="Cobertura model coverage" checked="${instance.isModelCovChecked}">
+  	  <f:entry field="modelCoverageChkBxFilePath" title="Save Cobertura mode">
+  	  <f:textbox default="matlabTestArtifacts/modelcoverage.xml"/>
+  	  </f:entry>
    </f:optionalBlock>
 </f:section>
 </j:jelly>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
@@ -2,30 +2,42 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     
 <f:section title="Generate Test Artifacts">
-  	 <f:entry field="pdfReportChkBx">	
-    	<f:checkbox title="PDF test report " name="pdfReportChkBx" checked="${instance.pdfReportChkBx}"/>	
+    <f:optionalBlock name="pdfReportChkBx" title="PDF test report" checked="${instance.pdfReportChkBx}" inline="true">
+  	 <f:entry field="pdfReportFilePath" title="Save PDF report at">	
+    	<f:textbox default="matlabTestArtifacts/testreport.pdf"/>
      </f:entry>
-
-	 <f:entry field="tapChkBx">
-    	<f:checkbox title="TAP test results" name="tapChkBx" checked="${instance.tapChkBx}"/>
+    </f:optionalBlock>
+    
+    <f:optionalBlock name="tapChkBx" title="TAP test results" checked="${instance.tapChkBx}" inline="true">   	
+     <f:entry field="tapChkBxFilePath" title="Save TAP report at">	
+    	<f:textbox default="matlabTestArtifacts/taptestresults.tap"/>
      </f:entry>
-     	
-  	  <f:entry field="junitChkBx">
-    	<f:checkbox title="JUnit-style test results" name="junitChkBx" checked="${instance.junitChkBx}"/>
+    </f:optionalBlock>
+     
+    <f:optionalBlock name="junitChkBx" title="JUnit-style test results" checked="${instance.junitChkBx}" inline="true"> 	
+  	  <f:entry field="junitChkBxFilePath" title="Save JUnit-style report at">
+    	<f:textbox default="matlabTestArtifacts/junittestresults.xml"/>
   	  </f:entry>      
-
-  	 <f:entry field="stmResultsChkBx">
-    	<f:checkbox title="Simulink Test Manager results" name="stmResultsChkBx" checked="${instance.stmResultsChkBx}"/>
+    </f:optionalBlock>
+    
+   <f:optionalBlock name="stmResultsChkBx" title="Simulink Test Manager results" checked="${instance.stmResultsChkBx}" inline="true">  
+  	 <f:entry field="stmResultsChkBxFilePath" title="Save Simulink Test Manager results at">
+    	<f:textbox default="matlabTestArtifacts/simulinktestresults.mldatx"/>
      </f:entry>   
+   </f:optionalBlock>
 </f:section>
 
 <f:section title="Generate Coverage Artifacts">
-	 <f:entry field="coberturaChkBx">
-    	<f:checkbox title="Cobertura code coverage" name="coberturaChkBx" checked="${instance.coberturaChkBx}"/>
+   <f:optionalBlock name="coberturaChkBx" title="Cobertura code coverage" checked="${instance.coberturaChkBx}" inline="true">
+	 <f:entry field="coberturaChkBxFilePath" title="Save Cobertura code coverage at">
+    	<f:textbox default="matlabTestArtifacts/cobertura.xml"/>
      </f:entry>
-     	
-  	  <f:entry field="modelCoverageChkBx">
-    	<f:checkbox title="Cobertura model coverage" name="modelCoverageChkBx" checked="${instance.modelCoverageChkBx}"/>
+   </f:optionalBlock>
+   
+   <f:optionalBlock name="modelCoverageChkBx" title="Cobertura model coverage" checked="${instance.modelCoverageChkBx}" inline="true">
+  	  <f:entry field="modelCoverageChkBxFilePath" title="Save Cobertura model coverage at">
+    	<f:textbox default="matlabTestArtifacts/coberturamodelcoverage.xml"/>
   	  </f:entry>  
+   </f:optionalBlock>
 </f:section>
 </j:jelly>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
@@ -2,25 +2,25 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     
 <f:section title="Generate Test Artifacts">
-    <f:optionalBlock name="pdfReportChkBx" field="pdfReportChkBx" title="PDF test report" checked="${instance.isPdfChecked}">
+    <f:optionalBlock name="pdfReportArtifact" field="pdfReportArtifact" title="PDF test report" checked="${instance.pdfReportArtifact != null}">
   	 <f:entry field="pdfReportFilePath" title="File path: ">	
     	<f:textbox default="matlabTestArtifacts/testreport.pdf"/>
      </f:entry>
     </f:optionalBlock>
      
-    <f:optionalBlock name="tapChkBx" field="tapChkBx" title="TAP test results" checked="${instance.isTapChecked}">   	
+    <f:optionalBlock name="tapArtifact" field="tapArtifact" title="TAP test results" checked="${instance.tapArtifact != null}">   	
      <f:entry field="tapReportFilePath" title="File path: ">	
     	<f:textbox default="matlabTestArtifacts/taptestresults.tap"/>
      </f:entry>
     </f:optionalBlock>
      
-    <f:optionalBlock name="junitChkBx" field="junitChkBx" title="JUnit-style test results" checked="${instance.isJunitChecked}"> 	
+    <f:optionalBlock name="junitArtifact" field="junitArtifact" title="JUnit-style test results" checked="${instance.junitArtifact != null}"> 	
   	  <f:entry field="junitReportFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/junittestresults.xml"/>
   	  </f:entry>      
     </f:optionalBlock>
     
-   <f:optionalBlock name="stmResultsChkBx" field="stmResultsChkBx" title="Simulink Test Manager results" checked="${instance.isStmChecked}">  
+   <f:optionalBlock name="stmResultsArtifact" field="stmResultsArtifact" title="Simulink Test Manager results" checked="${instance.stmResultsArtifact != null}">  
   	 <f:entry field="stmResultsFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/simulinktestresults.mldatx"/>
      </f:entry>   
@@ -29,13 +29,13 @@
 </f:section>
 
 <f:section title="Generate Coverage Artifacts">
-   <f:optionalBlock name="coberturaChkBx" field="coberturaChkBx" title="Cobertura code coverage" checked="${instance.isCoberturaChecked}">
+   <f:optionalBlock name="coberturaArtifact" field="coberturaArtifact" title="Cobertura code coverage" checked="${instance.coberturaArtifact != null}">
 	 <f:entry field="coberturaReportFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/cobertura.xml"/>
      </f:entry>
    </f:optionalBlock>
    
-   <f:optionalBlock name="modelCoverageChkBx" field="modelCoverageChkBx" title="Cobertura model coverage" checked="${instance.isModelCovChecked}">
+   <f:optionalBlock name="modelCoverageArtifact" field="modelCoverageArtifact" title="Cobertura model coverage" checked="${instance.modelCoverageArtifact != null}">
   	  <f:entry field="modelCoverageFilePath" title="File path: ">
   	  <f:textbox default="matlabTestArtifacts/modelcoverage.xml"/>
   	  </f:entry>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
@@ -3,25 +3,25 @@
     
 <f:section title="Generate Test Artifacts">
     <f:optionalBlock name="pdfReportChkBx" field="pdfReportChkBx" title="PDF test report" checked="${instance.isPdfChecked}">
-  	 <f:entry field="pdfReportFilePath" title="Save PDF report at">	
+  	 <f:entry field="pdfReportFilePath" title="File location ">	
     	<f:textbox default="matlabTestArtifacts/testreport.pdf"/>
      </f:entry>
     </f:optionalBlock>
      
     <f:optionalBlock name="tapChkBx" field="tapChkBx" title="TAP test results" checked="${instance.isTapChecked}">   	
-     <f:entry field="tapChkBxFilePath" title="Save TAP report at">	
+     <f:entry field="tapReportFilePath" title="File location ">	
     	<f:textbox default="matlabTestArtifacts/taptestresults.tap"/>
      </f:entry>
     </f:optionalBlock>
      
     <f:optionalBlock name="junitChkBx" field="junitChkBx" title="JUnit-style test results" checked="${instance.isJunitChecked}"> 	
-  	  <f:entry field="junitChkBxFilePath" title="Save JUnit-style report at">
+  	  <f:entry field="junitReportFilePath" title="File location ">
     	<f:textbox default="matlabTestArtifacts/junittestresults.xml"/>
   	  </f:entry>      
     </f:optionalBlock>
     
    <f:optionalBlock name="stmResultsChkBx" field="stmResultsChkBx" title="Simulink Test Manager results" checked="${instance.isStmChecked}">  
-  	 <f:entry field="stmResultsChkBxFilePath" title="Save Simulink Test Manager results at">
+  	 <f:entry field="stmResultsFilePath" title="File location ">
     	<f:textbox default="matlabTestArtifacts/simulinktestresults.mldatx"/>
      </f:entry>   
    </f:optionalBlock>
@@ -30,13 +30,13 @@
 
 <f:section title="Generate Coverage Artifacts">
    <f:optionalBlock name="coberturaChkBx" field="coberturaChkBx" title="Cobertura code coverage" checked="${instance.isCoberturaChecked}">
-	 <f:entry field="coberturaChkBxFilePath" title="Save Cobertura code coverage at">
+	 <f:entry field="coberturaReportFilePath" title="File location ">
     	<f:textbox default="matlabTestArtifacts/cobertura.xml"/>
      </f:entry>
    </f:optionalBlock>
    
    <f:optionalBlock name="modelCoverageChkBx" field="modelCoverageChkBx" title="Cobertura model coverage" checked="${instance.isModelCovChecked}">
-  	  <f:entry field="modelCoverageChkBxFilePath" title="Save Cobertura mode">
+  	  <f:entry field="modelCoverageFilePath" title="File location ">
   	  <f:textbox default="matlabTestArtifacts/modelcoverage.xml"/>
   	  </f:entry>
    </f:optionalBlock>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/config.jelly
@@ -2,25 +2,25 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     
 <f:section title="Generate Test Artifacts">
-    <f:optionalBlock name="pdfReportArtifact" field="pdfReportArtifact" title="PDF test report" checked="${instance.pdfReportArtifact != null}">
+    <f:optionalBlock name="pdfReportArtifact" field="pdfReportArtifact" title="PDF test report" checked="${instance.pdfReportArtifact.default}">
   	 <f:entry field="pdfReportFilePath" title="File path: ">	
     	<f:textbox default="matlabTestArtifacts/testreport.pdf"/>
      </f:entry>
     </f:optionalBlock>
      
-    <f:optionalBlock name="tapArtifact" field="tapArtifact" title="TAP test results" checked="${instance.tapArtifact != null}">   	
+    <f:optionalBlock name="tapArtifact" field="tapArtifact" title="TAP test results" checked="${instance.tapArtifact.default}">   	
      <f:entry field="tapReportFilePath" title="File path: ">	
     	<f:textbox default="matlabTestArtifacts/taptestresults.tap"/>
      </f:entry>
     </f:optionalBlock>
      
-    <f:optionalBlock name="junitArtifact" field="junitArtifact" title="JUnit-style test results" checked="${instance.junitArtifact != null}"> 	
+    <f:optionalBlock name="junitArtifact" field="junitArtifact" title="JUnit-style test results" checked="${instance.junitArtifact.default}"> 	
   	  <f:entry field="junitReportFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/junittestresults.xml"/>
   	  </f:entry>      
     </f:optionalBlock>
     
-   <f:optionalBlock name="stmResultsArtifact" field="stmResultsArtifact" title="Simulink Test Manager results" checked="${instance.stmResultsArtifact != null}">  
+   <f:optionalBlock name="stmResultsArtifact" field="stmResultsArtifact" title="Simulink Test Manager results" checked="${instance.stmResultsArtifact.default}">  
   	 <f:entry field="stmResultsFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/simulinktestresults.mldatx"/>
      </f:entry>   
@@ -29,13 +29,13 @@
 </f:section>
 
 <f:section title="Generate Coverage Artifacts">
-   <f:optionalBlock name="coberturaArtifact" field="coberturaArtifact" title="Cobertura code coverage" checked="${instance.coberturaArtifact != null}">
+   <f:optionalBlock name="coberturaArtifact" field="coberturaArtifact" title="Cobertura code coverage" checked="${instance.coberturaArtifact.default}">
 	 <f:entry field="coberturaReportFilePath" title="File path: ">
     	<f:textbox default="matlabTestArtifacts/cobertura.xml"/>
      </f:entry>
    </f:optionalBlock>
    
-   <f:optionalBlock name="modelCoverageArtifact" field="modelCoverageArtifact" title="Cobertura model coverage" checked="${instance.modelCoverageArtifact != null}">
+   <f:optionalBlock name="modelCoverageArtifact" field="modelCoverageArtifact" title="Cobertura model coverage" checked="${instance.modelCoverageArtifact.default}">
   	  <f:entry field="modelCoverageFilePath" title="File path: ">
   	  <f:textbox default="matlabTestArtifacts/modelcoverage.xml"/>
   	  </f:entry>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/runMatlabTests.m
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/runMatlabTests.m
@@ -4,32 +4,21 @@ function failed = runMatlabTests(varargin)
 
 
 p = inputParser;
-p.addParameter('PDFReport', false, @islogical);
-p.addParameter('PDFReportPath', 'matlabTestArtifacts/testreport.pdf', @ischar);
-p.addParameter('TAPResults', false, @islogical);
-p.addParameter('TAPResultsPath', 'matlabTestArtifacts/taptestresults.tap', @ischar);
-p.addParameter('JUnitResults', false, @islogical);
-p.addParameter('JUnitResultsPath', 'matlabTestArtifacts/junittestresults.xml', @ischar);
-p.addParameter('SimulinkTestResults', false, @islogical);
-p.addParameter('SimulinkTestResultsPath', 'matlabTestArtifacts/simulinktestresults.mldatx', @ischar);
-p.addParameter('CoberturaCodeCoverage', false, @islogical);
-p.addParameter('CoberturaCodeCoveragePath', 'matlabTestArtifacts/cobertura.xml', @ischar);
-p.addParameter('CoberturaModelCoverage', false, @islogical);
-p.addParameter('CoberturaModelCoveragePath', 'matlabTestArtifacts/coberturamodelcoverage.xml', @ischar);
+p.addParameter('PDFReportPath', '', @ischar);
+p.addParameter('TAPResultsPath', '', @ischar);
+p.addParameter('JUnitResultsPath', '', @ischar);
+p.addParameter('SimulinkTestResultsPath', '', @ischar);
+p.addParameter('CoberturaCodeCoveragePath', '', @ischar);
+p.addParameter('CoberturaModelCoveragePath', '', @ischar);
 
 p.parse(varargin{:});
 
-producePDFReport         = p.Results.PDFReport;
+
 pdfReportPath            = p.Results.PDFReportPath;
-produceTAP               = p.Results.TAPResults;
 tapReportPath            = p.Results.TAPResultsPath;
-produceJUnit             = p.Results.JUnitResults;
 junitReportPath          = p.Results.JUnitResultsPath;
-exportSTMResults         = p.Results.SimulinkTestResults;
 stmReportPath            = p.Results.SimulinkTestResultsPath;
-produceCobertura         = p.Results.CoberturaCodeCoverage;
 coberturaReportPath      = p.Results.CoberturaCodeCoveragePath;
-produceModelCoverage     = p.Results.CoberturaModelCoverage;
 modelCoveragePath        = p.Results.CoberturaModelCoveragePath;
 
 BASE_VERSION_MATLABUNIT_SUPPORT = '8.1';
@@ -48,7 +37,7 @@ runner = TestRunner.withTextOutput;
 
 
 % Produce JUnit report
-if produceJUnit
+if ~isempty(junitReportPath)
     BASE_VERSION_JUNIT_SUPPORT = '8.6';
     if verLessThan('matlab',BASE_VERSION_JUNIT_SUPPORT)
         warning('MATLAB:testArtifact:junitReportNotSupported', 'Producing JUnit xml results is not supported in this release.');
@@ -60,7 +49,7 @@ if produceJUnit
 end
 
 % Produce TAP report
-if produceTAP
+if ~isempty(tapReportPath)
     BASE_VERSION_TAPORIGINALFORMAT_SUPPORT = '8.3';
     BASE_VERSION_TAP13_SUPPORT = '9.1';
     if verLessThan('matlab',BASE_VERSION_TAPORIGINALFORMAT_SUPPORT)
@@ -81,7 +70,7 @@ end
 
 % Produce Cobertura report (Cobertura report generation is not supported
 % below R17a) 
-if produceCobertura 
+if ~isempty(coberturaReportPath) 
     BASE_VERSION_COBERTURA_SUPPORT = '9.3';
     
     if verLessThan('matlab',BASE_VERSION_COBERTURA_SUPPORT)
@@ -96,7 +85,7 @@ if produceCobertura
 end
 
 % Produce Cobertura model coverage report (Not supported below R2018b) 
-if produceModelCoverage
+if ~isempty(modelCoveragePath)
     if ~exist('sltest.plugins.ModelCoveragePlugin', 'class') || ~coberturaModelCoverageSupported
         warning('MATLAB:testArtifact:cannotGenerateModelCoverageReport', ...
                 'Unable to generate Cobertura model coverage report. To generate the report, use a Simulink Coverage license with MATLAB R2018b or a newer release.');
@@ -111,7 +100,7 @@ end
 stmResultsPluginAddedToRunner = false;
 
 % Save Simulink Test Manager results in MLDATX format (Not supported below R2019a)
-if exportSTMResults
+if ~isempty(stmReportPath)
     if ~stmResultsPluginPresent || ~exportSTMResultsSupported
         issueExportSTMResultsUnsupportedWarning;
     else
@@ -122,7 +111,7 @@ if exportSTMResults
 end
 
 % Produce PDF test report (Not supported on MacOS platforms and below R2017a)
-if producePDFReport
+if ~isempty(pdfReportPath)
     if ismac
         warning('MATLAB:testArtifact:unSupportedPlatform', ...
             'Producing a PDF test report is not currently supported on MacOS platforms.');

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/runMatlabTests.m
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsBuilder/runMatlabTests.m
@@ -139,11 +139,11 @@ if ~dirExists
     mkdir(dir);		    
 end
 
-function tapToFile = getTapResultFile(resultsDir)
+function tapFile = getTapResultFile(resultsDir)
 import('matlab.unittest.plugins.ToFile');
 preparePath(resultsDir);
 fclose(fopen(resultsDir,'w'));
-tapToFile = matlab.unittest.plugins.ToFile(resultsDir);
+tapFile = matlab.unittest.plugins.ToFile(resultsDir);
 
 function suite = getTestSuite()
 import('matlab.unittest.TestSuite');

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
@@ -27,12 +27,12 @@ import com.gargoylesoftware.htmlunit.WebAssert;
 import com.gargoylesoftware.htmlunit.html.HtmlCheckBoxInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.mathworks.ci.MatlabBuilder.RunTestsAutomaticallyOption;
-import com.mathworks.ci.RunMatlabTestsBuilder.CoberturaChkBx;
-import com.mathworks.ci.RunMatlabTestsBuilder.JunitChkBx;
-import com.mathworks.ci.RunMatlabTestsBuilder.ModelCovChkBx;
-import com.mathworks.ci.RunMatlabTestsBuilder.PdfChkBx;
-import com.mathworks.ci.RunMatlabTestsBuilder.StmResultsChkBx;
-import com.mathworks.ci.RunMatlabTestsBuilder.TapChkBx;
+import com.mathworks.ci.RunMatlabTestsBuilder.CoberturaArtifact;
+import com.mathworks.ci.RunMatlabTestsBuilder.JunitArtifact;
+import com.mathworks.ci.RunMatlabTestsBuilder.ModelCovArtifact;
+import com.mathworks.ci.RunMatlabTestsBuilder.PdfArtifact;
+import com.mathworks.ci.RunMatlabTestsBuilder.StmResultsArtifact;
+import com.mathworks.ci.RunMatlabTestsBuilder.TapArtifact;
 import hudson.FilePath;
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
@@ -229,14 +229,14 @@ public class RunMatlabTestsBuilderTest {
     public void verifySpecificTestArtifactsParameters() throws Exception {
         this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2018b"));
         project.getBuildWrappersList().add(this.buildWrapper);
-        RunMatlabTestsBuilder.TapChkBx tap = new TapChkBx();
+        RunMatlabTestsBuilder.TapArtifact tap = new TapArtifact();
         tap.setTapReportFilePath("mytap/report.tap");
 
-        RunMatlabTestsBuilder.StmResultsChkBx stmResults = new StmResultsChkBx();
+        RunMatlabTestsBuilder.StmResultsArtifact stmResults = new StmResultsArtifact();
         stmResults.setStmResultsFilePath("mystm/results.mldatx");
 
-        testBuilder.setTapChkBx(tap);
-        testBuilder.setStmResultsChkBx(stmResults);
+        testBuilder.setTapArtifact(tap);
+        testBuilder.setStmResultsArtifact(stmResults);
 
 
         project.getBuildersList().add(this.testBuilder);
@@ -256,19 +256,19 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildWrappersList().add(this.buildWrapper);
         project.getBuildersList().add(this.testBuilder);
         HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
-        HtmlCheckBoxInput tapChkBx = page.getElementByName("tapChkBx");
-        HtmlCheckBoxInput pdfReportChkBx = page.getElementByName("pdfReportChkBx");
-        HtmlCheckBoxInput junitChkBx = page.getElementByName("junitChkBx");
-        HtmlCheckBoxInput stmResultsChkBx = page.getElementByName("stmResultsChkBx");
-        HtmlCheckBoxInput coberturaChkBx = page.getElementByName("coberturaChkBx");
-        HtmlCheckBoxInput modelCoverageChkBx = page.getElementByName("modelCoverageChkBx");
+        HtmlCheckBoxInput tapArtifact = page.getElementByName("tapArtifact");
+        HtmlCheckBoxInput pdfReportArtifact = page.getElementByName("pdfReportArtifact");
+        HtmlCheckBoxInput junitArtifact = page.getElementByName("junitArtifact");
+        HtmlCheckBoxInput stmResultsArtifact = page.getElementByName("stmResultsArtifact");
+        HtmlCheckBoxInput coberturaArtifact = page.getElementByName("coberturaArtifact");
+        HtmlCheckBoxInput modelCoverageArtifact = page.getElementByName("modelCoverageArtifact");
         
-        tapChkBx.click();
-        pdfReportChkBx.click();
-        junitChkBx.click();
-        stmResultsChkBx.click();
-        coberturaChkBx.click();
-        modelCoverageChkBx.click();
+        tapArtifact.click();
+        pdfReportArtifact.click();
+        junitArtifact.click();
+        stmResultsArtifact.click();
+        coberturaArtifact.click();
+        modelCoverageArtifact.click();
         Thread.sleep(2000);
         
         WebAssert.assertTextPresent(page,"matlabTestArtifacts/taptestresults.tap");
@@ -287,30 +287,30 @@ public class RunMatlabTestsBuilderTest {
     public void verifyAllTestArtifactsParameters() throws Exception {
         this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2018b"));
         project.getBuildWrappersList().add(this.buildWrapper);
-        RunMatlabTestsBuilder.TapChkBx tap = new TapChkBx();
+        RunMatlabTestsBuilder.TapArtifact tap = new TapArtifact();
         tap.setTapReportFilePath("mytap/report.tap");
         
-        RunMatlabTestsBuilder.PdfChkBx pdf = new PdfChkBx();
+        RunMatlabTestsBuilder.PdfArtifact pdf = new PdfArtifact();
         pdf.setPdfReportFilePath("mypdf/report.pdf");
         
-        RunMatlabTestsBuilder.JunitChkBx junit = new JunitChkBx();
+        RunMatlabTestsBuilder.JunitArtifact junit = new JunitArtifact();
         junit.setJunitReportFilePath("myjunit/report.xml");
         
-        RunMatlabTestsBuilder.CoberturaChkBx cobertura = new CoberturaChkBx();
+        RunMatlabTestsBuilder.CoberturaArtifact cobertura = new CoberturaArtifact();
         cobertura.setCoberturaReportFilePath("mycobertura/report.xml");
         
-        RunMatlabTestsBuilder.ModelCovChkBx modelCov = new ModelCovChkBx();
+        RunMatlabTestsBuilder.ModelCovArtifact modelCov = new ModelCovArtifact();
         modelCov.setModelCoverageFilePath("mymodel/report.xml");
         
-        RunMatlabTestsBuilder.StmResultsChkBx stmResults = new StmResultsChkBx();
+        RunMatlabTestsBuilder.StmResultsArtifact stmResults = new StmResultsArtifact();
         stmResults.setStmResultsFilePath("mystm/results.mldatx");
         
-        testBuilder.setTapChkBx(tap);
-        testBuilder.setPdfReportChkBx(pdf);
-        testBuilder.setJunitChkBx(junit);
-        testBuilder.setCoberturaChkBx(cobertura);
-        testBuilder.setModelCoverageChkBx(modelCov);
-        testBuilder.setStmResultsChkBx(stmResults);
+        testBuilder.setTapArtifact(tap);
+        testBuilder.setPdfReportArtifact(pdf);
+        testBuilder.setJunitArtifact(junit);
+        testBuilder.setCoberturaArtifact(cobertura);
+        testBuilder.setModelCoverageArtifact(modelCov);
+        testBuilder.setStmResultsArtifact(stmResults);
         
         
         project.getBuildersList().add(this.testBuilder);

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
+import org.codehaus.groovy.vmplugin.v5.JUnit4Utils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,6 +27,7 @@ import com.gargoylesoftware.htmlunit.WebAssert;
 import com.gargoylesoftware.htmlunit.html.HtmlCheckBoxInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.mathworks.ci.MatlabBuilder.RunTestsAutomaticallyOption;
+import com.mathworks.ci.RunMatlabTestsBuilder.TapChkBx;
 import hudson.FilePath;
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
@@ -113,7 +114,7 @@ public class RunMatlabTestsBuilderTest {
     @Test
     public void verifyBuildStepWithMatlabTestBuilder() throws Exception {
         boolean found = false;
-        setAllTestArtifacts(false, testBuilder);
+        //setAllTestArtifacts(false, testBuilder);
         project.getBuildersList().add(testBuilder);
         List<Builder> bl = project.getBuildersList();
         for (Builder b : bl) {
@@ -134,7 +135,7 @@ public class RunMatlabTestsBuilderTest {
     public void verifyMATLABlaunchedWithDefaultArgumentsBatch() throws Exception {
         this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2018b"));
         project.getBuildWrappersList().add(this.buildWrapper);
-        setAllTestArtifacts(false, this.testBuilder);
+        //setAllTestArtifacts(false, this.testBuilder);
         project.getBuildersList().add(this.testBuilder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertLogContains("run_matlab_command", build);
@@ -150,7 +151,7 @@ public class RunMatlabTestsBuilderTest {
     public void verifyMATLABlaunchedWithDefaultArgumentsRWindows() throws Exception {
         this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2017a"));
         project.getBuildWrappersList().add(this.buildWrapper);
-        setAllTestArtifacts(false, this.testBuilder);
+        //setAllTestArtifacts(false, this.testBuilder);
         project.getBuildersList().add(testBuilder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertLogContains("run_matlab_command", build);
@@ -165,7 +166,7 @@ public class RunMatlabTestsBuilderTest {
     public void verifyBuilderFailsForInvalidMATLABPath() throws Exception {
         this.buildWrapper.setMatlabRootFolder("/fake/matlabroot/that/does/not/exist");
         project.getBuildWrappersList().add(this.buildWrapper);
-        setAllTestArtifacts(false, this.testBuilder);
+        //setAllTestArtifacts(false, this.testBuilder);
         project.getBuildersList().add(this.testBuilder);
 
         FreeStyleBuild build = project.scheduleBuild2(0).get();
@@ -182,7 +183,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildWrappersList().add(this.buildWrapper);
         RunMatlabTestsBuilderTester tester =
                 new RunMatlabTestsBuilderTester(matlabExecutorAbsolutePath, "-positiveFail");
-        setAllTestArtifacts(false, tester);
+        //setAllTestArtifacts(false, tester);
         project.getBuildersList().add(tester);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertBuildStatus(Result.FAILURE, build);
@@ -198,7 +199,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildWrappersList().add(this.buildWrapper);
         RunMatlabTestsBuilderTester tester =
                 new RunMatlabTestsBuilderTester(matlabExecutorAbsolutePath, "-positive");
-        setAllTestArtifacts(false, tester);
+        //setAllTestArtifacts(false, tester);
         project.getBuildersList().add(tester);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertBuildStatus(Result.SUCCESS, build);
@@ -222,20 +223,62 @@ public class RunMatlabTestsBuilderTest {
     }
 
     /*
-     * Test to verify if Automatic option passes appropriate test atrtifact values.
+     * Test to verify appropriate test atrtifact values are passed.
      */
 
     @Test
-    public void verifyRunTestAutomaticallyIsDefault() throws Exception {
+    public void verifyAllTestArtifactsParameters() throws Exception {
         this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2018b"));
         project.getBuildWrappersList().add(this.buildWrapper);
-        setAllTestArtifacts(true, testBuilder);
+        RunMatlabTestsBuilder.TapChkBx tap = testBuilder.new TapChkBx();
+        tap.setTapReportFilePath("mytap/report.tap");
+        
+        RunMatlabTestsBuilder.PdfChkBx pdf = testBuilder.new PdfChkBx();
+        pdf.setPdfReportFilePath("mypdf/report.pdf");
+        
+        RunMatlabTestsBuilder.JunitChkBx junit = testBuilder.new JunitChkBx();
+        junit.setJunitReportFilePath("myjunit/report.xml");
+        
+        RunMatlabTestsBuilder.CoberturaChkBx cobertura = testBuilder.new CoberturaChkBx();
+        cobertura.setCoberturaReportFilePath("mycobertura/report.xml");
+        
+        RunMatlabTestsBuilder.ModelCovChkBx modelCov = testBuilder.new ModelCovChkBx();
+        modelCov.setModelCoverageFilePath("mymodel/report.xml");
+        
+        RunMatlabTestsBuilder.StmResultsChkBx stmResults = testBuilder.new StmResultsChkBx();
+        stmResults.setStmResultsFilePath("mystm/results.mldatx");
+        
+        testBuilder.setTapChkBx(tap);
+        testBuilder.setPdfReportChkBx(pdf);
+        testBuilder.setJunitChkBx(junit);
+        testBuilder.setCoberturaChkBx(cobertura);
+        testBuilder.setModelCoverageChkBx(modelCov);
+        testBuilder.setStmResultsChkBx(stmResults);
+        
+        
         project.getBuildersList().add(this.testBuilder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertLogContains("run_matlab_command", build);
-        jenkins.assertLogContains("\'PDFReport\',true,\'TAPResults\',true,"
-                + "\'JUnitResults\',true,\'SimulinkTestResults\',true,"
-                + "\'CoberturaCodeCoverage\',true,\'CoberturaModelCoverage\',true", build);
+        jenkins.assertLogContains("\'PDFReportPath\',\'mypdf/report.pdf\',"
+                + "\'TAPResultsPath\',\'mytap/report.tap\',"
+                + "\'JUnitResultsPath\',\'myjunit/report.xml\',"
+                + "\'SimulinkTestResultsPath\',\'mystm/results.mldatx\',"
+                + "\'CoberturaCodeCoveragePath\',\'mycobertura/report.xml\',"
+                + "\'CoberturaModelCoveragePath\',\'mymodel/report.xml\'", build);
+    }
+    
+    /*
+     * Test to verify no parameters are sent in runMatlabTests when no artifacts are selected.
+     */
+
+    @Test
+    public void veriyEmptyParameters() throws Exception {
+        this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2018b"));
+        project.getBuildWrappersList().add(this.buildWrapper);
+        project.getBuildersList().add(this.testBuilder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        jenkins.assertLogContains("run_matlab_command", build);
+        jenkins.assertLogContains("exit(runMatlabTests())", build);
     }
 
     
@@ -246,7 +289,7 @@ public class RunMatlabTestsBuilderTest {
     public void verifyMATLABrunnerFileGeneratedForAutomaticOption() throws Exception {
         this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2018b"));
         project.getBuildWrappersList().add(this.buildWrapper);
-        setAllTestArtifacts(false, testBuilder);
+        //setAllTestArtifacts(false, testBuilder);
         project.getBuildersList().add(testBuilder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertLogContains("MATLAB_ROOT", build);
@@ -264,7 +307,7 @@ public class RunMatlabTestsBuilderTest {
 		this.buildWrapper.setMatlabRootFolder(matlabRoot.replace("R2018b", "$VERSION"));
 		matrixProject.getBuildWrappersList().add(this.buildWrapper);
 
-		setAllTestArtifacts(false, testBuilder);
+		//setAllTestArtifacts(false, testBuilder);
 		matrixProject.getBuildersList().add(testBuilder);
 
 		// Check for first matrix combination.
@@ -299,7 +342,7 @@ public class RunMatlabTestsBuilderTest {
 		matrixProject.getBuildWrappersList().add(this.buildWrapper);
 		RunMatlabTestsBuilderTester tester = new RunMatlabTestsBuilderTester(matlabExecutorAbsolutePath, "-positive");
 
-		setAllTestArtifacts(false, tester);
+		//setAllTestArtifacts(false, tester);
 		matrixProject.getBuildersList().add(tester);
 		MatrixBuild build = matrixProject.scheduleBuild2(0).get();
 
@@ -316,7 +359,7 @@ public class RunMatlabTestsBuilderTest {
     public void verifyMATLABscratchFileGenerated() throws Exception {
         this.buildWrapper.setMatlabRootFolder(getMatlabroot("R2018b"));  
         project.getBuildWrappersList().add(this.buildWrapper);
-        setAllTestArtifacts(false, testBuilder);
+        //setAllTestArtifacts(false, testBuilder);
         project.getBuildersList().add(testBuilder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         File matlabRunner = new File(build.getWorkspace() + File.separator + "runMatlabTests.m");
@@ -336,7 +379,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(this.testBuilder);
         HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
         HtmlCheckBoxInput coberturaChkBx = page.getElementByName("coberturaChkBx");
-        coberturaChkBx.setChecked(true);
+        coberturaChkBx.click();
         Thread.sleep(2000);
         WebAssert.assertTextPresent(page,
                 TestMessage.getValue("Builder.matlab.cobertura.support.warning"));
@@ -355,7 +398,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(this.testBuilder);
         HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
         HtmlCheckBoxInput modelCoverageChkBx = page.getElementByName("modelCoverageChkBx");
-        modelCoverageChkBx.setChecked(true);
+        modelCoverageChkBx.click();
         Thread.sleep(2000);
         WebAssert.assertTextPresent(page,
                 TestMessage.getValue("Builder.matlab.modelcoverage.support.warning"));
@@ -374,7 +417,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(this.testBuilder);
         HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
         HtmlCheckBoxInput stmResultsChkBx = page.getElementByName("stmResultsChkBx");
-        stmResultsChkBx.setChecked(true);
+        stmResultsChkBx.click();
         Thread.sleep(2000);
         WebAssert.assertTextPresent(page,
                 TestMessage.getValue("Builder.matlab.exportstmresults.support.warning"));
@@ -392,7 +435,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(this.testBuilder);
         HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
         HtmlCheckBoxInput coberturaChkBx = page.getElementByName("coberturaChkBx");
-        coberturaChkBx.setChecked(true);
+        coberturaChkBx.click();
         Thread.sleep(2000);
         String pageText = page.asText();
         String filteredPageText = pageText
@@ -414,7 +457,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(this.testBuilder);
         HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
         HtmlCheckBoxInput modelCoverageChkBx = page.getElementByName("modelCoverageChkBx");
-        modelCoverageChkBx.setChecked(true);
+        modelCoverageChkBx.click();
         Thread.sleep(2000);
         String pageText = page.asText();
         String filteredPageText = pageText
@@ -436,7 +479,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(this.testBuilder);
         HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
         HtmlCheckBoxInput stmResultsChkBx = page.getElementByName("stmResultsChkBx");
-        stmResultsChkBx.setChecked(true);
+        stmResultsChkBx.click();
         Thread.sleep(2000);
         String pageText = page.asText();
         String filteredPageText = pageText
@@ -444,14 +487,4 @@ public class RunMatlabTestsBuilderTest {
         Assert.assertTrue(filteredPageText
                 .contains(TestMessage.getValue("Builder.invalid.matlab.root.warning")));
     }
-
-    private void setAllTestArtifacts(boolean val, RunMatlabTestsBuilder testBuilder) {
-        testBuilder.setCoberturaChkBx(val);
-        testBuilder.setJunitChkBx(val);
-        testBuilder.setModelCoverageChkBx(val);
-        testBuilder.setPdfReportChkBx(val);
-        testBuilder.setTapChkBx(val);
-        testBuilder.setStmResultsChkBx(val);
-    }
-
 }

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTester.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTester.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.codehaus.groovy.vmplugin.v5.JUnit4Utils;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 import hudson.EnvVars;
@@ -28,12 +27,12 @@ import net.sf.json.JSONObject;
 
 public class RunMatlabTestsBuilderTester extends RunMatlabTestsBuilder {
 
-    private TapChkBx tapChkBx;
-    private JunitChkBx junitChkBx;
-    private CoberturaChkBx coberturaChkBx;
-    private StmResultsChkBx stmResultsChkBx;
-    private ModelCovChkBx modelCoverageChkBx;
-    private PdfChkBx pdfReportChkBx;
+    private TapArtifact tapChkBx;
+    private JunitArtifact junitChkBx;
+    private CoberturaArtifact coberturaChkBx;
+    private StmResultsArtifact stmResultsChkBx;
+    private ModelCovArtifact modelCoverageChkBx;
+    private PdfArtifact pdfReportChkBx;
     private EnvVars env;
     private int buildResult;
     private MatlabReleaseInfo matlabRel;
@@ -55,56 +54,56 @@ public class RunMatlabTestsBuilderTester extends RunMatlabTestsBuilder {
 
 
     @DataBoundSetter
-    public void setTapChkBx(TapChkBx tapChkBx) {
+    public void setTapChkBx(TapArtifact tapChkBx) {
         this.tapChkBx = tapChkBx;
     }
 
     @DataBoundSetter
-    public void setJunitChkBx(JunitChkBx junitChkBx) {
+    public void setJunitChkBx(JunitArtifact junitChkBx) {
         this.junitChkBx = junitChkBx;
     }
 
     @DataBoundSetter
-    public void setCoberturaChkBx(CoberturaChkBx coberturaChkBx) {
+    public void setCoberturaChkBx(CoberturaArtifact coberturaChkBx) {
         this.coberturaChkBx = coberturaChkBx;
     }
 
     @DataBoundSetter
-    public void setStmResultsChkBx(StmResultsChkBx stmResultsChkBx) {
+    public void setStmResultsChkBx(StmResultsArtifact stmResultsChkBx) {
         this.stmResultsChkBx = stmResultsChkBx;
     }
 
     @DataBoundSetter
-    public void setModelCoverageChkBx(ModelCovChkBx modelCoverageChkBx) {
+    public void setModelCoverageChkBx(ModelCovArtifact modelCoverageChkBx) {
         this.modelCoverageChkBx = modelCoverageChkBx;
     }
 
     @DataBoundSetter
-    public void setPdfReportChkBx(PdfChkBx pdfReportChkBx) {
+    public void setPdfReportChkBx(PdfArtifact pdfReportChkBx) {
         this.pdfReportChkBx = pdfReportChkBx;
     }
 
-    public TapChkBx getTapChkBx() {
+    public TapArtifact getTapChkBx() {
         return tapChkBx;
     }
 
-    public JunitChkBx getJunitChkBx() {
+    public JunitArtifact getJunitChkBx() {
         return junitChkBx;
     }
 
-    public CoberturaChkBx getCoberturaChkBx() {
+    public CoberturaArtifact getCoberturaChkBx() {
         return coberturaChkBx;
     }
 
-    public StmResultsChkBx getStmResultsChkBx() {
+    public StmResultsArtifact getStmResultsChkBx() {
         return stmResultsChkBx;
     }
 
-    public ModelCovChkBx getModelCoverageChkBx() {
+    public ModelCovArtifact getModelCoverageChkBx() {
         return modelCoverageChkBx;
     }
 
-    public PdfChkBx getPdfReportChkBx() {
+    public PdfArtifact getPdfReportChkBx() {
         return pdfReportChkBx;
     }
 

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTester.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTester.java
@@ -27,12 +27,12 @@ import net.sf.json.JSONObject;
 
 public class RunMatlabTestsBuilderTester extends RunMatlabTestsBuilder {
 
-    private TapArtifact tapChkBx;
-    private JunitArtifact junitChkBx;
-    private CoberturaArtifact coberturaChkBx;
-    private StmResultsArtifact stmResultsChkBx;
-    private ModelCovArtifact modelCoverageChkBx;
-    private PdfArtifact pdfReportChkBx;
+    private Artifact tapArtifact = new NullArtifact();;
+    private Artifact junitArtifact = new NullArtifact();;
+    private Artifact coberturaArtifact = new NullArtifact();;
+    private Artifact stmResultsArtifact = new NullArtifact();;
+    private Artifact modelCoverageArtifact = new NullArtifact();
+    private Artifact pdfReportArtifact = new NullArtifact();;
     private EnvVars env;
     private int buildResult;
     private MatlabReleaseInfo matlabRel;
@@ -54,57 +54,57 @@ public class RunMatlabTestsBuilderTester extends RunMatlabTestsBuilder {
 
 
     @DataBoundSetter
-    public void setTapChkBx(TapArtifact tapChkBx) {
-        this.tapChkBx = tapChkBx;
+    public void setTapChkBx(TapArtifact tapArtifact) {
+        this.tapArtifact = tapArtifact;
     }
 
     @DataBoundSetter
-    public void setJunitChkBx(JunitArtifact junitChkBx) {
-        this.junitChkBx = junitChkBx;
+    public void setJunitChkBx(JunitArtifact junitArtifact) {
+        this.junitArtifact = junitArtifact;
     }
 
     @DataBoundSetter
-    public void setCoberturaChkBx(CoberturaArtifact coberturaChkBx) {
-        this.coberturaChkBx = coberturaChkBx;
+    public void setCoberturaChkBx(CoberturaArtifact coberturaArtifact) {
+        this.coberturaArtifact = coberturaArtifact;
     }
 
     @DataBoundSetter
-    public void setStmResultsChkBx(StmResultsArtifact stmResultsChkBx) {
-        this.stmResultsChkBx = stmResultsChkBx;
+    public void setStmResultsChkBx(StmResultsArtifact stmResultsArtifact) {
+        this.stmResultsArtifact = stmResultsArtifact;
     }
 
     @DataBoundSetter
-    public void setModelCoverageChkBx(ModelCovArtifact modelCoverageChkBx) {
-        this.modelCoverageChkBx = modelCoverageChkBx;
+    public void setModelCoverageChkBx(ModelCovArtifact modelCoverageArtifact) {
+        this.modelCoverageArtifact = modelCoverageArtifact;
     }
 
     @DataBoundSetter
-    public void setPdfReportChkBx(PdfArtifact pdfReportChkBx) {
-        this.pdfReportChkBx = pdfReportChkBx;
+    public void setPdfReportChkBx(PdfArtifact pdfReportArtifact) {
+        this.pdfReportArtifact = pdfReportArtifact;
     }
 
-    public TapArtifact getTapChkBx() {
-        return tapChkBx;
+    public Artifact getTapChkBx() {
+        return tapArtifact;
     }
 
-    public JunitArtifact getJunitChkBx() {
-        return junitChkBx;
+    public Artifact getJunitChkBx() {
+        return junitArtifact;
     }
 
-    public CoberturaArtifact getCoberturaChkBx() {
-        return coberturaChkBx;
+    public Artifact getCoberturaChkBx() {
+        return coberturaArtifact;
     }
 
-    public StmResultsArtifact getStmResultsChkBx() {
-        return stmResultsChkBx;
+    public Artifact getStmResultsChkBx() {
+        return stmResultsArtifact;
     }
 
-    public ModelCovArtifact getModelCoverageChkBx() {
-        return modelCoverageChkBx;
+    public Artifact getModelCoverageChkBx() {
+        return modelCoverageArtifact;
     }
 
-    public PdfArtifact getPdfReportChkBx() {
-        return pdfReportChkBx;
+    public Artifact getPdfReportChkBx() {
+        return pdfReportArtifact;
     }
 
     private void setEnv(EnvVars env) {

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTester.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTester.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.codehaus.groovy.vmplugin.v5.JUnit4Utils;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 import hudson.EnvVars;
@@ -27,12 +28,12 @@ import net.sf.json.JSONObject;
 
 public class RunMatlabTestsBuilderTester extends RunMatlabTestsBuilder {
 
-    private boolean tapChkBx;
-    private boolean junitChkBx;
-    private boolean coberturaChkBx;
-    private boolean stmResultsChkBx;
-    private boolean modelCoverageChkBx;
-    private boolean pdfReportChkBx;
+    private TapChkBx tapChkBx;
+    private JunitChkBx junitChkBx;
+    private CoberturaChkBx coberturaChkBx;
+    private StmResultsChkBx stmResultsChkBx;
+    private ModelCovChkBx modelCoverageChkBx;
+    private PdfChkBx pdfReportChkBx;
     private EnvVars env;
     private int buildResult;
     private MatlabReleaseInfo matlabRel;
@@ -54,56 +55,56 @@ public class RunMatlabTestsBuilderTester extends RunMatlabTestsBuilder {
 
 
     @DataBoundSetter
-    public void setTapChkBx(boolean tapChkBx) {
+    public void setTapChkBx(TapChkBx tapChkBx) {
         this.tapChkBx = tapChkBx;
     }
 
     @DataBoundSetter
-    public void setJunitChkBx(boolean junitChkBx) {
+    public void setJunitChkBx(JunitChkBx junitChkBx) {
         this.junitChkBx = junitChkBx;
     }
 
     @DataBoundSetter
-    public void setCoberturaChkBx(boolean coberturaChkBx) {
+    public void setCoberturaChkBx(CoberturaChkBx coberturaChkBx) {
         this.coberturaChkBx = coberturaChkBx;
     }
 
     @DataBoundSetter
-    public void setStmResultsChkBx(boolean stmResultsChkBx) {
+    public void setStmResultsChkBx(StmResultsChkBx stmResultsChkBx) {
         this.stmResultsChkBx = stmResultsChkBx;
     }
 
     @DataBoundSetter
-    public void setModelCoverageChkBx(boolean modelCoverageChkBx) {
+    public void setModelCoverageChkBx(ModelCovChkBx modelCoverageChkBx) {
         this.modelCoverageChkBx = modelCoverageChkBx;
     }
 
     @DataBoundSetter
-    public void setPdfReportChkBx(boolean pdfReportChkBx) {
+    public void setPdfReportChkBx(PdfChkBx pdfReportChkBx) {
         this.pdfReportChkBx = pdfReportChkBx;
     }
 
-    public boolean getTapChkBx() {
+    public TapChkBx getTapChkBx() {
         return tapChkBx;
     }
 
-    public boolean getJunitChkBx() {
+    public JunitChkBx getJunitChkBx() {
         return junitChkBx;
     }
 
-    public boolean getCoberturaChkBx() {
+    public CoberturaChkBx getCoberturaChkBx() {
         return coberturaChkBx;
     }
 
-    public boolean getStmResultsChkBx() {
+    public StmResultsChkBx getStmResultsChkBx() {
         return stmResultsChkBx;
     }
 
-    public boolean getModelCoverageChkBx() {
+    public ModelCovChkBx getModelCoverageChkBx() {
         return modelCoverageChkBx;
     }
 
-    public boolean getPdfReportChkBx() {
+    public PdfChkBx getPdfReportChkBx() {
         return pdfReportChkBx;
     }
 

--- a/src/test/java/com/mathworks/ci/UseMatlabVersionBuildWrapperTest.java
+++ b/src/test/java/com/mathworks/ci/UseMatlabVersionBuildWrapperTest.java
@@ -96,12 +96,6 @@ public class UseMatlabVersionBuildWrapperTest {
         this.buildWrapper.setMatlabRootFolder("/test/MATLAB/R2019a");
         project.getBuildWrappersList().add(this.buildWrapper);
         RunMatlabTestsBuilderTester buildTester = new RunMatlabTestsBuilderTester("","");
-        buildTester.setCoberturaChkBx(false);
-        buildTester.setJunitChkBx(false);
-        buildTester.setModelCoverageChkBx(false);
-        buildTester.setPdfReportChkBx(false);
-        buildTester.setTapChkBx(false);
-        buildTester.setStmResultsChkBx(false);   
         project.getBuildersList().add(buildTester);
         project.scheduleBuild2(0).get();
         Assert.assertTrue("Build does not have MATLAB build environment", this.buildWrapper.getMatlabRootFolder().equalsIgnoreCase(buildTester.getMatlabRoot()));


### PR DESCRIPTION
Hi Andy , tried your suggestion and figured out the following things.

* Need to maintain the duplicate strings in builder class else it would not resurrect on screen .
* we cant use Interface and / or Abstract class to implement null object pattern  as stapler  class always try to instantiate the class that it has been made a type of 

eg : Artifcat tapArtifact = new NullArtifact();

Stapler will always try to instantiate  Artifcat and it fails when its either abstract or interface with error like below.

Caused by: org.kohsuke.stapler.NoStaplerConstructorException: There's no @DataBoundConstructor on any constructor of interface com.mathworks.ci.RunMatlabTestsBuilder$Artifact
	at org.kohsuke.stapler.ClassDescriptor.loadConstructorParamNames(ClassDescriptor.java:247)
	at org.kohsuke.stapler.RequestImpl.instantiate(RequestImpl.java:758)
	at org.kohsuke.stapler.RequestImpl.access$200(RequestImpl.java:83)
	at org.kohsuke.stapler.RequestImpl$TypePair.convertJSON(RequestImpl.java:674)

* in this draft i have tried to use a Artifact as parent class and tried to implement the null object pattern however i am kind of fuguring out on how i could handdle the UI checkbox issue without checking for NULL in the builder class.