### PR TITLE
Fix Java Temp Path discrepancy for Window

### DIFF
--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -45,6 +45,9 @@ public interface MatlabBuild {
             copyFileInWorkspace(MatlabBuilderConstants.SHELL_RUNNER_SCRIPT, runnerScriptName,
                     targetWorkspace);
         } else {
+            if (tmpDir.charAt(tmpDir.length() - 1) == '\\'){
+                tmpDir = tmpDir.substring(0, tmpDir.length() - 1);
+            }
             final String runnerScriptName = uniqueName + "\\run_matlab_command.bat";
             launcher = launcher.decorateByPrefix("cmd.exe", "/C");
             matlabLauncher = launcher.launch().envs(envVars);
@@ -81,11 +84,8 @@ public interface MatlabBuild {
         // Handle Java Temp Path discrepancy for Windows.
         if (!launcher.isUnix()){
             fileSeperator = "\\";
-            System.out.println("In Windows check;");
             if (tmpDir.charAt(tmpDir.length() - 1) == '\\'){
-                System.out.println("tmpdir = " + tmpDir);
                 tmpDir = tmpDir.substring(0, tmpDir.length() - 1);
-                System.out.println("tmpdirAfter = " + tmpDir);
             }
         }
 

--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -33,7 +33,7 @@ public interface MatlabBuild {
             Launcher launcher, TaskListener listener, EnvVars envVars, String matlabCommand, String uniqueName)
             throws IOException, InterruptedException {
         // Get node specific tmp directory to copy matlab runner script
-        String tmpDir = getNodeSpecificTmpFolderPath(workspace);
+        String tmpDir = getNodeSpecificTmpFolderPath(workspace, launcher);
         FilePath targetWorkspace = new FilePath(launcher.getChannel(), tmpDir);
         ProcStarter matlabLauncher;
         if (launcher.isUnix()) {
@@ -45,9 +45,6 @@ public interface MatlabBuild {
             copyFileInWorkspace(MatlabBuilderConstants.SHELL_RUNNER_SCRIPT, runnerScriptName,
                     targetWorkspace);
         } else {
-            if (tmpDir.charAt(tmpDir.length() - 1) == '\\'){
-                tmpDir = tmpDir.substring(0, tmpDir.length() - 1);
-            }
             final String runnerScriptName = uniqueName + "\\run_matlab_command.bat";
             launcher = launcher.decorateByPrefix("cmd.exe", "/C");
             matlabLauncher = launcher.launch().envs(envVars);
@@ -78,26 +75,28 @@ public interface MatlabBuild {
         /*Use of Computer is not recommended as jenkins hygeine for pipeline support
          * https://javadoc.jenkins-ci.org/jenkins/tasks/SimpleBuildStep.html */
         
-        String tmpDir = getNodeSpecificTmpFolderPath(workspace);
+        String tmpDir = getNodeSpecificTmpFolderPath(workspace, launcher);
         String fileSeperator = "/";
 
-        // Handle Java Temp Path discrepancy for Windows.
         if (!launcher.isUnix()){
             fileSeperator = "\\";
-            if (tmpDir.charAt(tmpDir.length() - 1) == '\\'){
-                tmpDir = tmpDir.substring(0, tmpDir.length() - 1);
-            }
         }
 
         return new FilePath(launcher.getChannel(), tmpDir + fileSeperator + uniqueName);
     }
 
-    default String getNodeSpecificTmpFolderPath(FilePath workspace) throws IOException, InterruptedException {
+    default String getNodeSpecificTmpFolderPath(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {
         Computer cmp = workspace.toComputer();
         if (cmp == null) {
             throw new IOException(Message.getValue("build.workspace.computer.not.found"));
         }
         String tmpDir = (String) cmp.getSystemProperties().get("java.io.tmpdir");
+
+        // Handle Java temp folder path discrepancy for Windows.
+        if (!launcher.isUnix() && tmpDir.charAt(tmpDir.length() - 1) == '\\'){
+            tmpDir = tmpDir.substring(0, tmpDir.length() - 1);
+        }
+
         return tmpDir;
     }
 

--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -8,7 +8,6 @@ package com.mathworks.ci;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.File;
 import java.util.UUID;
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -77,13 +76,8 @@ public interface MatlabBuild {
          * https://javadoc.jenkins-ci.org/jenkins/tasks/SimpleBuildStep.html */
         
         String tmpDir = getNodeSpecificTmpFolderPath(workspace);
-        String fileSeperator = "/";
 
-        if (!launcher.isUnix()){
-            fileSeperator = "\\";
-        }
-
-        return new FilePath(launcher.getChannel(), tmpDir + fileSeperator + uniqueName);
+        return new FilePath(launcher.getChannel(), tmpDir + "/" + uniqueName);
     }
 
     default String getNodeSpecificTmpFolderPath(FilePath workspace) throws IOException, InterruptedException {
@@ -94,8 +88,8 @@ public interface MatlabBuild {
         
         String tmpDirPath = (String) cmp.getSystemProperties().get("java.io.tmpdir");
 
-        // Invoke FilePath.normalize for clean file path.
-        FilePath tmpDir = new FilePath(new File(tmpDirPath));
+        // Invoke FilePath.normalize for clean file path on any channel.
+        FilePath tmpDir = new FilePath(cmp.getChannel(), tmpDirPath);
         return tmpDir.getRemote();
     }
 

--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -33,7 +33,7 @@ public interface MatlabBuild {
             Launcher launcher, TaskListener listener, EnvVars envVars, String matlabCommand, String uniqueName)
             throws IOException, InterruptedException {
         // Get node specific tmp directory to copy matlab runner script
-        String tmpDir = getNodeSpecificTmpFolderPath(workspace);
+        String tmpDir = getNodeSpecificTmpFolderPath(workspace, launcher);
         FilePath targetWorkspace = new FilePath(launcher.getChannel(), tmpDir);
         ProcStarter matlabLauncher;
         if (launcher.isUnix()) {
@@ -75,16 +75,23 @@ public interface MatlabBuild {
         /*Use of Computer is not recommended as jenkins hygeine for pipeline support
          * https://javadoc.jenkins-ci.org/jenkins/tasks/SimpleBuildStep.html */
         
-        String tmpDir = getNodeSpecificTmpFolderPath(workspace);
+        String tmpDir = getNodeSpecificTmpFolderPath(workspace, launcher);
         return new FilePath(launcher.getChannel(), tmpDir+"/"+uniqueName);
     }
 
-    default String getNodeSpecificTmpFolderPath(FilePath workspace) throws IOException, InterruptedException {
+    default String getNodeSpecificTmpFolderPath(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {
         Computer cmp = workspace.toComputer();
         if (cmp == null) {
             throw new IOException(Message.getValue("build.workspace.computer.not.found"));
         }
         String tmpDir = (String) cmp.getSystemProperties().get("java.io.tmpdir");
+
+        // Handle Java Temp Path discrepancy for Windows.
+        if (!launcher.isUnix()){
+            if (tmpDir.charAt(tmpDir.length() - 1) == '\\'){
+                tmpDir = tmpDir.substring(0, tmpDir.length() - 1);
+            }
+        }
         return tmpDir;
     }
 

--- a/src/test/java/com/mathworks/ci/RunMatlabCommandBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabCommandBuilderTest.java
@@ -249,6 +249,9 @@ public class RunMatlabCommandBuilderTest {
     
     /*
      * Test to verify if appropriate MATALB runner file is copied in workspace.
+     * 
+     * NOTE: This test assumes there is no MATLAB installed and is not on System Path.
+     * 
      */
     @Test
     public void verifyMATLABrunnerFileGenerated() throws Exception {
@@ -262,6 +265,9 @@ public class RunMatlabCommandBuilderTest {
     
 	/*
 	 * Test to verify if Matrix build fails when MATLAB is not available.
+     * 
+     * NOTE: This test assumes there is no MATLAB installed and is not on System Path.
+     * 
 	 */
 	@Test
 	public void verifyMatrixBuildFails() throws Exception {

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
@@ -334,6 +334,9 @@ public class RunMatlabTestsBuilderTest {
     
     /*
      * Test to verify if appropriate MATALB runner file is copied in workspace.
+     * 
+     * NOTE: This test assumes there is no MATLAB installed and is not on System Path.
+     *
      */
     @Test
     public void verifyMATLABrunnerFileGeneratedForAutomaticOption() throws Exception {
@@ -346,6 +349,9 @@ public class RunMatlabTestsBuilderTest {
     
 	/*
 	 * Test to verify if Matrix build fails when MATLAB is not available.
+     * 
+     * NOTE: This test assumes there is no MATLAB installed and is not on System Path.
+     *
 	 */
 	@Test
 	public void verifyMatrixBuildFails() throws Exception {

--- a/src/test/java/com/mathworks/ci/TestStepExecution.java
+++ b/src/test/java/com/mathworks/ci/TestStepExecution.java
@@ -35,6 +35,9 @@ public class TestStepExecution extends MatlabRunTestsStepExecution {
             // Copy runner .sh for linux platform in workspace.
             copyFileInWorkspace("run_matlab_command_test.sh", runnerScriptName, targetWorkspace);
         } else {
+            if (tmpDir.charAt(tmpDir.length() - 1) == '\\'){
+                tmpDir = tmpDir.substring(0, tmpDir.length() - 1);
+            }
             final String runnerScriptName = uniqueName + "\\run_matlab_command_test.bat";
             launcher = launcher.decorateByPrefix("cmd.exe", "/C");
             matlabLauncher = launcher.launch().pwd(workspace).envs(envVars)

--- a/src/test/java/com/mathworks/ci/TestStepExecution.java
+++ b/src/test/java/com/mathworks/ci/TestStepExecution.java
@@ -24,7 +24,7 @@ public class TestStepExecution extends MatlabRunTestsStepExecution {
             TaskListener listener, EnvVars envVars, String matlabCommand, String uniqueName)
             throws IOException, InterruptedException {
         // Get node specific tmp directory to copy matlab runner script
-        String tmpDir = getNodeSpecificTmpFolderPath(workspace);
+        String tmpDir = getNodeSpecificTmpFolderPath(workspace, launcher);
         FilePath targetWorkspace = new FilePath(launcher.getChannel(), tmpDir);
         ProcStarter matlabLauncher;
         if (launcher.isUnix()) {
@@ -35,9 +35,6 @@ public class TestStepExecution extends MatlabRunTestsStepExecution {
             // Copy runner .sh for linux platform in workspace.
             copyFileInWorkspace("run_matlab_command_test.sh", runnerScriptName, targetWorkspace);
         } else {
-            if (tmpDir.charAt(tmpDir.length() - 1) == '\\'){
-                tmpDir = tmpDir.substring(0, tmpDir.length() - 1);
-            }
             final String runnerScriptName = uniqueName + "\\run_matlab_command_test.bat";
             launcher = launcher.decorateByPrefix("cmd.exe", "/C");
             matlabLauncher = launcher.launch().pwd(workspace).envs(envVars)

--- a/src/test/java/com/mathworks/ci/TestStepExecution.java
+++ b/src/test/java/com/mathworks/ci/TestStepExecution.java
@@ -24,7 +24,7 @@ public class TestStepExecution extends MatlabRunTestsStepExecution {
             TaskListener listener, EnvVars envVars, String matlabCommand, String uniqueName)
             throws IOException, InterruptedException {
         // Get node specific tmp directory to copy matlab runner script
-        String tmpDir = getNodeSpecificTmpFolderPath(workspace, launcher);
+        String tmpDir = getNodeSpecificTmpFolderPath(workspace);
         FilePath targetWorkspace = new FilePath(launcher.getChannel(), tmpDir);
         ProcStarter matlabLauncher;
         if (launcher.isUnix()) {

--- a/src/test/java/com/mathworks/ci/TestStepExecution.java
+++ b/src/test/java/com/mathworks/ci/TestStepExecution.java
@@ -24,7 +24,7 @@ public class TestStepExecution extends MatlabRunTestsStepExecution {
             TaskListener listener, EnvVars envVars, String matlabCommand, String uniqueName)
             throws IOException, InterruptedException {
         // Get node specific tmp directory to copy matlab runner script
-        String tmpDir = getNodeSpecificTmpFolderPath(workspace);
+        String tmpDir = getNodeSpecificTmpFolderPath(workspace, launcher);
         FilePath targetWorkspace = new FilePath(launcher.getChannel(), tmpDir);
         ProcStarter matlabLauncher;
         if (launcher.isUnix()) {


### PR DESCRIPTION
Remove extra back slash from temp folder path generation for Windows platform.
Added comment to tests stating Test assumes there's no Matlab installed and no Matlab on Path.