### PR TITLE
Replaced runMatlabTests.m rferance in document.

### DIFF
--- a/CONFIGDOC.md
+++ b/CONFIGDOC.md
@@ -60,7 +60,7 @@ The **Run MATLAB Tests** build step enables you to generate different types of t
 
 If you do not select any of the test artifact check boxes, the tests still run, and test failures fail the build.
 
-The **Run MATLAB Tests** build step produces a MATLAB script file, Content of this file will be printed on console log during build. The plugin uses this file to run the tests and generate the test artifacts. You can review the contents of the script to understand the testing workflow.
+The **Run MATLAB Tests** build step produces a MATLAB script file and uses it to run the tests and generate the test artifacts. The plugin writes the contents of this file to the build log. You can review the build log in **Console Output** to understand the testing workflow.
  
 **Note:**
 * The plugin does not create the `matlabTestArtifacts` folder if the name of the folder does not appear in any of the displayed **File path** boxes.

--- a/CONFIGDOC.md
+++ b/CONFIGDOC.md
@@ -60,7 +60,7 @@ The **Run MATLAB Tests** build step enables you to generate different types of t
 
 If you do not select any of the test artifact check boxes, the tests still run, and test failures fail the build.
 
-The **Run MATLAB Tests** build step produces a MATLAB script file named `runMatlabTests.m` in the project workspace. The plugin uses this file to run the tests and generate the test artifacts. You can review the contents of the script to understand the testing workflow.
+The **Run MATLAB Tests** build step produces a MATLAB script file, Content of this file will be printed on console log during build. The plugin uses this file to run the tests and generate the test artifacts. You can review the contents of the script to understand the testing workflow.
  
 **Note:**
 * The plugin does not create the `matlabTestArtifacts` folder if the name of the folder does not appear in any of the displayed **File path** boxes.


### PR DESCRIPTION
* With gen script changes in. we need to remove occurrences of `runMatlabTests.m` file from the document.  
* The Script file will not be available to refer once the build is complete. Instead printed on the console log during the build. 