### PR TITLE
Filter tests

### DIFF
--- a/src/main/java/com/mathworks/ci/RunMatlabTestsStep.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabTestsStep.java
@@ -32,7 +32,9 @@ public class RunMatlabTestsStep extends Step {
     private String codeCoverageCobertura;
     private String testResultsSimulinkTest;
     private String modelCoverageCobertura;
+    private String selectByTag;
     private List<String> sourceFolder = new ArrayList<>();
+    private List<String> selectByFolder = new ArrayList<>();
 
     @DataBoundConstructor
     public RunMatlabTestsStep() {
@@ -102,6 +104,24 @@ public class RunMatlabTestsStep extends Step {
     public void setSourceFolder(List<String> sourceFolder) {
         this.sourceFolder = Util.fixNull(sourceFolder);
     }
+    
+    public String getSelectByTag() {
+        return this.selectByTag;
+    }
+    
+    @DataBoundSetter
+    public void setSelectByTag(String selectByTag) {
+        this.selectByTag = selectByTag;
+    }
+    
+    public List<String> getSelectByFolder() {
+        return this.selectByFolder;
+    }
+    
+    @DataBoundSetter
+    public void setSelectByFolder(List<String> selectByFolder) {
+        this.selectByFolder = selectByFolder;
+    }
 
     @Override
     public StepExecution start(StepContext context) throws Exception {
@@ -135,7 +155,7 @@ public class RunMatlabTestsStep extends Step {
         inputArgs.add("'Test'");
 
         args.forEach((key, val) -> {
-            if(key.equals("SourceFolder") && val != null){
+            if(key.equals("SourceFolder") || key.equals("SelectByFolder") && val != null){
                 inputArgs.add("'" + key + "'" + "," + val);
             }else if(val != null){
                 inputArgs.add("'" + key + "'" + "," + "'" + val.replaceAll("'", "''") + "'");
@@ -153,9 +173,15 @@ public class RunMatlabTestsStep extends Step {
         args.put("SimulinkTestResults", getTestResultsSimulinkTest());
         args.put("CoberturaCodeCoverage", getCodeCoverageCobertura());
         args.put("CoberturaModelCoverage", getModelCoverageCobertura());
-        if(!getSourceFolder().isEmpty()){
-            args.put("SourceFolder", Utilities.getCellArrayFrmList(getSourceFolder()));
-        }
+        args.put("SelectByTag", getSelectByTag());
+        addFolderArgs("SourceFolder",getSourceFolder(),args);
+        addFolderArgs("SelectByFolder",getSelectByFolder(),args);
         return args;
+    }
+    
+    private void addFolderArgs(String argName,List<String> value,Map<String,String> args) {
+        if(!value.isEmpty()){
+            args.put(argName, Utilities.getCellArrayFrmList(value));
+        }
     }
 }

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/config.jelly
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/config.jelly
@@ -1,6 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     
+    
 	  <f:entry field="testResultsPDF" title="testResultsPDF: ">
 	        <f:textbox/>
 	  </f:entry> 
@@ -23,6 +24,14 @@
 	  
 	  <f:entry field="modelCoverageCobertura" title="modelCoverageCobertura: ">
 	        <f:textbox/>
+	  </f:entry>
+	  
+	  <f:entry field="selectByFolder" title="selectByFolder: ">
+		<f:textbox/>
+	  </f:entry>
+	  
+	  <f:entry field="selectByTag" title="selectByTag: ">
+		<f:textbox/>
 	  </f:entry>
 
 	<f:entry field="sourceFolder" title="sourceFolder: ">

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByFolder.html
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByFolder.html
@@ -1,4 +1,4 @@
 <div>
-    <p>Specify the location of folders containing test code, relative to the project root folder, as a string array. The specified folders and their subfolders are added to the test suite runner.</p>
-    <p><b>Example:</b> ["test/unitTest", "test/IntegTests"]</p>
+    <p>Specify the locations of folders containing tests, relative to the project root folder, as a list of string. To generate a test suite, MATLAB uses only the tests in the specified folders and their subfolders.</p>
+    <p><b>Example:</b> ["test/folderA", "test/folderB"]</p>
 </div>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByFolder.html
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByFolder.html
@@ -1,4 +1,4 @@
 <div>
-    <p>Specify the locations of folders containing tests, relative to the project root folder, as a list of string. To generate a test suite, MATLAB uses only the tests in the specified folders and their subfolders.</p>
+    <p>Specify the locations of folders containing tests, relative to the project root folder, as a list of strings. To generate a test suite, MATLAB uses only the tests in the specified folders and their subfolders.</p>
     <p><b>Example:</b> ["test/folderA", "test/folderB"]</p>
 </div>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByFolder.html
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByFolder.html
@@ -1,0 +1,4 @@
+<div>
+    <p>Specify the location of folders containing test code, relative to the project root folder, as a string array. The specified folders and their subfolders are added to the test suite runner.</p>
+    <p><b>Example:</b> ["test/unitTest", "test/IntegTests"]</p>
+</div>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByTag.html
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByTag.html
@@ -1,3 +1,4 @@
 <div>
-    <p>Specify the test Tag name. Test which are tagged with specified name will be added to test suite and will be considered to run.</p>
+    <p>Specify the test tag used to select test suite elements. To generate a test suite, MATLAB uses only the test elements with the specified tag.</p>
+    <p><b>Example:</b> 'FeatureA'</p>
 </div>

--- a/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByTag.html
+++ b/src/main/resources/com/mathworks/ci/RunMatlabTestsStep/help-selectByTag.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Specify the test Tag name. Test which are tagged with specified name will be added to test suite and will be considered to run.</p>
+</div>

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsStepTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsStepTest.java
@@ -125,4 +125,29 @@ public class RunMatlabTestsStepTest {
         j.assertLogNotContains("SimulinkTestResultsPath", build);
         j.assertLogNotContains("CoberturaModelCoveragePath", build);
     }
+    
+    /*@Integ Test
+     * Verify default command options for test Filter using selectByFolder option 
+     */
+
+    public void verifyTestSelectByFolder () throws Exception {
+        project.setDefinition(new CpsFlowDefinition(
+                "node {runMATLABTests(selectByFolder:['mytest1','mytest2'])}", true));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        j.assertLogContains("mytest1", build);
+        j.assertLogContains("mytest2", build);
+        j.assertBuildStatusSuccess(build);
+    }
+    
+    /*@Integ Test
+     * Verify default command options for test Filter using selectByTag option 
+     */
+
+    public void verifyTestSelectByTag () throws Exception {
+        project.setDefinition(new CpsFlowDefinition(
+                "node {runMATLABTests(selectByTag: 'myTestTag')}", true));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        j.assertLogContains("myTestTag", build);
+        j.assertBuildStatusSuccess(build);
+    }
 }


### PR DESCRIPTION
* Pipeline support for filtering tests by Folder & Tag name 
* Added two new parameters `selectByFolder` and `selectByTag` are added 
* `selectbyFolder` accepts list of test folder names. eg `selectByFolder: ['testfolder1','testfolder2']`
* Added Integration tests for the same.