### PR TITLE
Support docker

### DIFF
--- a/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
@@ -32,7 +32,10 @@ public class MatlabBuilderConstants {
     static final String MATLAB_SCRIPT_GENERATOR = "matlab-script-generator.zip";
     
     //Test runner file prefix 
-    static final String MATLAB_TEST_RUNNER_FILE_PREFIX = "test_runner_";
+    static final String MATLAB_TEST_RUNNER_FILE_PREFIX = "runner_";
+    
+    //Temporary MATLAB folder name in workspace 
+    static final String TEMP_MATLAB_FOLDER_NAME = ".matlab";
     
     // MATLAB runner script
     static final String TEST_RUNNER_SCRIPT = "testScript = genscript(${PARAMS});\n" + "\n"

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -19,7 +19,6 @@ Builder.matlab.modelcoverage.support.warning = To generate a Cobertura model cov
 Builder.matlab.exportstmresults.support.warning = To export Simulink Test Manager results, use MATLAB R2019a or a newer release.
 Builder.matlab.runner.script.target.file.linux.name = run_matlab_command.sh
 Builder.matlab.runner.script.target.file.windows.name = run_matlab_command.bat
-build.workspace.computer.not.found = Unable to access the computer for this build.
 matlab.command.build.step.name = runMATLABCommand
 matlab.tests.build.step.name = runMATLABTests
 matlab.command.step.display.name = Run MATLAB commands, scripts, or functions

--- a/src/test/java/com/mathworks/ci/RunMatlabCommandBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabCommandBuilderTest.java
@@ -355,4 +355,18 @@ public class RunMatlabCommandBuilderTest {
         jenkins.assertLogContains("Generating MATLAB script with content", build);
         jenkins.assertLogContains(expectedCommand, build);
     }
+    
+    /*
+     * Test to verify if .matlab temp folder generated in workspace.
+     */
+    @Test
+    public void verifyMATLABtmpFolderGenerated() throws Exception {
+        this.buildWrapper.setMatlabBuildWrapperContent(new MatlabBuildWrapperContent(Message.getValue("matlab.custom.location"), getMatlabroot("R2018b")));
+        project.getBuildWrappersList().add(this.buildWrapper);
+        scriptBuilder.setMatlabCommand("pwd");
+        project.getBuildersList().add(this.scriptBuilder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        File matlabRunner = new File(build.getWorkspace() + File.separator + ".matlab");
+        Assert.assertTrue(matlabRunner.exists());
+    }
 }

--- a/src/test/java/com/mathworks/ci/RunMatlabCommandStepTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabCommandStepTest.java
@@ -151,4 +151,19 @@ public class RunMatlabCommandStepTest {
         j.assertLogContains("com.mathworks.ci.MatlabExecutionException", build);
         j.assertLogContains(String.format(Message.getValue("matlab.execution.exception.prefix"), 1), build);
     }
+    
+    /*
+     * Verify .matlab folder is generated 
+     *
+     */
+
+    @Test
+    public void verifyMATLABtempFolderGenerated() throws Exception {
+        project.setDefinition(
+                new CpsFlowDefinition("node { testMATLABCommand(command: 'pwd')}", true));
+
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        j.assertLogContains(".matlab", build);
+        j.assertBuildStatusSuccess(build);
+    }
 }

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsBuilderTest.java
@@ -141,7 +141,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(this.testBuilder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertLogContains("run_matlab_command", build);
-        jenkins.assertLogContains("test_runner", build);
+        jenkins.assertLogContains("runner", build);
         jenkins.assertLogContains("addpath(", build);
     }
 
@@ -157,7 +157,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(testBuilder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertLogContains("run_matlab_command", build);
-        jenkins.assertLogContains("test_runner", build);
+        jenkins.assertLogContains("runner", build);
     }
 
     /*
@@ -364,7 +364,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(this.testBuilder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertLogContains("run_matlab_command", build);
-        jenkins.assertLogContains("test_runner", build);
+        jenkins.assertLogContains("runner", build);
         jenkins.assertLogNotContains("\'PDFTestReport\',\'mypdf/report.pdf\'",build);
         jenkins.assertLogNotContains("\'TAPTestResults\',\'mytap/report.tap\'",build);
         jenkins.assertLogNotContains("\'JUnitTestResults\',\'myjunit/report.xml\'",build);
@@ -375,7 +375,7 @@ public class RunMatlabTestsBuilderTest {
     }
     
     /*
-     * Test to verify no parameters are sent in test_runner when no artifacts are selected.
+     * Test to verify no parameters are sent in test runner when no artifacts are selected.
      */
 
     @Test
@@ -385,7 +385,7 @@ public class RunMatlabTestsBuilderTest {
         project.getBuildersList().add(this.testBuilder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertLogContains("run_matlab_command", build);
-        jenkins.assertLogContains("test_runner", build);
+        jenkins.assertLogContains("runner", build);
     }
 
     
@@ -486,5 +486,18 @@ public class RunMatlabTestsBuilderTest {
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         File matlabRunner = new File(build.getWorkspace() + File.separator + "runMatlabTests.m");
         Assert.assertFalse(matlabRunner.exists());
+    }
+    
+    /*
+     * Test to verify if .matlab gets created in workspace.
+     */
+    @Test
+    public void verifyMATLABfolderGenerated() throws Exception {
+        this.buildWrapper.setMatlabBuildWrapperContent(new MatlabBuildWrapperContent(Message.getValue("matlab.custom.location"), getMatlabroot("R2018b")));
+        project.getBuildWrappersList().add(this.buildWrapper);
+        project.getBuildersList().add(testBuilder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        File matlabRunner = new File(build.getWorkspace() + File.separator + ".matlab");
+        Assert.assertTrue(matlabRunner.exists());
     }
 }

--- a/src/test/java/com/mathworks/ci/RunMatlabTestsStepTest.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabTestsStepTest.java
@@ -90,7 +90,7 @@ public class RunMatlabTestsStepTest {
                "node {runMATLABTests(testResultsPDF:'myresult/result.pdf')}", true));
        WorkflowRun build = project.scheduleBuild2(0).get();
        j.assertLogContains("addpath(", build);
-       j.assertLogContains("test_runner", build);
+       j.assertLogContains("runner", build);
    }
 
     /*
@@ -119,7 +119,7 @@ public class RunMatlabTestsStepTest {
         project.setDefinition(new CpsFlowDefinition(
                 "node {runMATLABTests()}", true));
         WorkflowRun build = project.scheduleBuild2(0).get();
-        j.assertLogContains("test_runner", build);
+        j.assertLogContains("runner", build);
         j.assertLogNotContains("PDFReportPath", build);
         j.assertLogNotContains("TAPResultsPath", build);
         j.assertLogNotContains("JUnitResultsPath", build);
@@ -135,6 +135,19 @@ public class RunMatlabTestsStepTest {
         WorkflowRun build = project.scheduleBuild2(0).get();
         j.assertBuildStatus(Result.FAILURE, build);
         j.assertLogContains(String.format(Message.getValue("matlab.execution.exception.prefix"), 1), build);
+    }
+    
+    /*
+     * Verify .matlab folder created 
+     */
+
+    @Test
+    public void verifyMATLABtempFolderGenerated() throws Exception {
+        project.setDefinition(new CpsFlowDefinition(
+                "node {testMATLABTests(testResultsPDF:'myresult/result.pdf')}", true));
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        j.assertBuildStatusSuccess(build);
+        j.assertLogContains(".matlab", build);
     }
     
     /*@Integ Test

--- a/src/test/java/com/mathworks/ci/TestStepExecution.java
+++ b/src/test/java/com/mathworks/ci/TestStepExecution.java
@@ -24,13 +24,15 @@ public class TestStepExecution extends MatlabRunTestsStepExecution {
             TaskListener listener, EnvVars envVars, String matlabCommand, String uniqueName)
             throws IOException, InterruptedException {
         // Get node specific tmp directory to copy matlab runner script
-        String tmpDir = getNodeSpecificTmpFolderPath(workspace);
-        FilePath targetWorkspace = new FilePath(launcher.getChannel(), tmpDir);
+        //String tmpDir = getNodeSpecificTmpFolderPath(workspace);
+        FilePath targetWorkspace = new FilePath(launcher.getChannel(),
+                workspace.getRemote() + "/" + MatlabBuilderConstants.TEMP_MATLAB_FOLDER_NAME);
+        
         ProcStarter matlabLauncher;
         if (launcher.isUnix()) {
             final String runnerScriptName = uniqueName + "/run_matlab_command_test.sh";
             matlabLauncher = launcher.launch().pwd(workspace).envs(envVars)
-                    .cmds(tmpDir + "/" + runnerScriptName, matlabCommand).stdout(listener);
+                    .cmds(MatlabBuilderConstants.TEMP_MATLAB_FOLDER_NAME + "/" + runnerScriptName, matlabCommand).stdout(listener);
 
             // Copy runner .sh for linux platform in workspace.
             copyFileInWorkspace("run_matlab_command_test.sh", runnerScriptName, targetWorkspace);
@@ -38,7 +40,7 @@ public class TestStepExecution extends MatlabRunTestsStepExecution {
             final String runnerScriptName = uniqueName + "\\run_matlab_command_test.bat";
             launcher = launcher.decorateByPrefix("cmd.exe", "/C");
             matlabLauncher = launcher.launch().pwd(workspace).envs(envVars)
-                    .cmds(tmpDir + "\\" + runnerScriptName, "\"" + matlabCommand + "\"")
+                    .cmds(MatlabBuilderConstants.TEMP_MATLAB_FOLDER_NAME + "\\" + runnerScriptName, "\"" + matlabCommand + "\"")
                     .stdout(listener);
             // Copy runner.bat for Windows platform in workspace.
             copyFileInWorkspace("run_matlab_command_test.bat", runnerScriptName, targetWorkspace);

--- a/src/test/java/com/mathworks/ci/TestStepExecution.java
+++ b/src/test/java/com/mathworks/ci/TestStepExecution.java
@@ -24,7 +24,6 @@ public class TestStepExecution extends MatlabRunTestsStepExecution {
             TaskListener listener, EnvVars envVars, String matlabCommand, String uniqueName)
             throws IOException, InterruptedException {
         // Get node specific tmp directory to copy matlab runner script
-        //String tmpDir = getNodeSpecificTmpFolderPath(workspace);
         FilePath targetWorkspace = new FilePath(launcher.getChannel(),
                 workspace.getRemote() + "/" + MatlabBuilderConstants.TEMP_MATLAB_FOLDER_NAME);
         


### PR DESCRIPTION
In order to support running our MATLAB tasks in docker instance following changes are incorporated in this PR 
* Copying all task related build resources from temp folder to Workspace 
*  There will be temporary folder created named `.matlab` in Jenkins workspace. 
* All resources will be copied in the same `.matlab` folder and will be invoked from the same location .
* Each task will create random folder and assign random names to the files and folders within `.matlab` 
* At the end of the build randomly generated folders and resources will be deleted except `.matlab` folder itself.
* Using 8 bit random UUI instead earlier 32 bit long UUID to cut short the screen space and better readability.