### PR TITLE
Fix for MATLAB root path displayed in Jenkins build logs.

### DIFF
--- a/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
+++ b/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
@@ -182,7 +182,7 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
         setEnv(initialEnvironment);
 
         FilePath matlabExecutablePath = new FilePath(launcher.getChannel(),
-                getNodeSpecificMatlab(Computer.currentComputer(), listener) + "/bin/" + getNodeSpecificExecutable(launcher));
+                getNodeSpecificMatlab(Computer.currentComputer(), listener) + getNodeSpecificExecutable(launcher));
 
         if (!matlabExecutablePath.exists()) {
             throw new MatlabNotFoundError(Message.getValue("matlab.not.found.error"));
@@ -196,6 +196,6 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
     }
 
     private String getNodeSpecificExecutable(Launcher launcher) {
-        return (launcher.isUnix()) ? "matlab" : "matlab.exe";
+        return (launcher.isUnix()) ? "/bin/matlab" : "\\bin\\matlab.exe";
     }
 }

--- a/src/main/java/com/mathworks/ci/Utilities.java
+++ b/src/main/java/com/mathworks/ci/Utilities.java
@@ -45,8 +45,9 @@ public class Utilities {
         }
 
         String matlabExecutablePath = getNodeSpecificHome(name,
-               cmp.getNode(), listener, env) + "/bin";
+               cmp.getNode(), listener, env) + ((Boolean.TRUE.equals(cmp.isUnix()))?"/bin" : "\\bin");
         env.put("PATH+matlabroot", matlabExecutablePath);
+
         // Specify which MATLAB was added to path.
         listener.getLogger().println("\n" + String.format(Message.getValue("matlab.added.to.path.from"), matlabExecutablePath) + "\n");
     }


### PR DESCRIPTION
This fixes the unmatched slashes in the MATLAB root path