### PR TITLE
2.8.1 snapshot qualification

### DIFF
--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -85,23 +85,27 @@ public interface MatlabBuild {
     
     // This method prepares the temp folder by coping all helper files in it.
     default void prepareTmpFldr(FilePath tmpFldr, String runnerScript) throws IOException, InterruptedException {
-        // Write MATLAB scratch file in temp folder.
-        FilePath scriptFile =
-                new FilePath(tmpFldr, getValidMatlabFileName(tmpFldr.getBaseName()) + ".m");
-        scriptFile.write(runnerScript, "UTF-8");
         // copy genscript package
         copyFileInWorkspace(MatlabBuilderConstants.MATLAB_SCRIPT_GENERATOR,
                 MatlabBuilderConstants.MATLAB_SCRIPT_GENERATOR, tmpFldr);
         FilePath zipFileLocation =
                 new FilePath(tmpFldr, MatlabBuilderConstants.MATLAB_SCRIPT_GENERATOR);
+        runnerScript=replaceZipPlaceholder(runnerScript, zipFileLocation.getRemote());
 
-        // Unzip the file in temp folder.
-        zipFileLocation.unzip(tmpFldr);
+        // Write MATLAB scratch file in temp folder.
+        FilePath scriptFile =
+                new FilePath(tmpFldr, getValidMatlabFileName(tmpFldr.getBaseName()) + ".m");
+        scriptFile.write(runnerScript, "UTF-8");
+    }
+
+    //This method replaces the placeholder with genscript's zip file location URL in temp folder
+    default String replaceZipPlaceholder(String script, String url) {
+        script = script.replace("${ZIP_FILE}", url.replaceAll("'","''"));
+        return script;
     }
     
     default String getRunnerScript(String script, String params, String uniqueTmpFldrName) {
         script = script.replace("${PARAMS}", params);
-        script = script.replaceAll("\\$\\{TMPDIR\\}", uniqueTmpFldrName);
         return script;
     }
     

--- a/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
@@ -37,14 +37,18 @@ public class MatlabBuilderConstants {
     //Temporary MATLAB folder name in workspace 
     static final String TEMP_MATLAB_FOLDER_NAME = ".matlab";
     
-    // MATLAB runner script
-    static final String TEST_RUNNER_SCRIPT = "testScript = genscript(${PARAMS});\n" + "\n"
-            + "disp('Running MATLAB script with content:');\n"
-            + "disp(strtrim(testScript.Contents));\n"
-            + "runnerFile = testScript.writeToFile(fullfile(tempname,'runnerScript.m'));\n"
-            + "[tmpDir,scriptName,ext] = fileparts(runnerFile);"
-            + "addpath(tmpDir);\n"
-            + "rmdir('.matlab/${TMPDIR}/+scriptgen', 's');\n"
-            + "delete('.matlab/${TMPDIR}/genscript.m');\n"
-            + "fprintf('___________________________________\\n\\n');\n";
+    static final String NEW_LINE = System.getProperty("line.separator");
+
+    //MATLAB Runner Script
+    static final String TEST_RUNNER_SCRIPT = String.join(NEW_LINE,
+    	"tmpDir=tempname;",
+        "mkdir(tmpDir);",
+        "addpath(tmpDir);",
+        "zipURL='${ZIP_FILE}';",
+    	"unzip(zipURL,tmpDir);",
+    	"testScript = genscript(${PARAMS});",
+        "disp('Running MATLAB script with content:');",
+        "disp(testScript.Contents);",
+        "testScript.writeToFile(fullfile(tmpDir,'runnerScript.m'));",
+    	"fprintf('___________________________________\\n\\n');");
 }


### PR DESCRIPTION
This PR closes #205 
Details:

1. New strategy to unzip MATLAB Scriptgen package to avoid being picked up by MATLAB Code Coverage tool
2. Supports both regular remote agents and container-based agents.
3. Earlier strategy- unzipping scriptgen inside .matlab folder in workspace.
4. New strategy-copy the scriptgen zip folder to system-specific temporary folder and unzip it here.
5. No helper files in the workspace.


