### PR TITLE
Fix bug where ClassLoader was unable to find run-matlab-command.exe f…

### DIFF
--- a/src/main/java/com/mathworks/ci/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuild.java
@@ -70,7 +70,7 @@ public interface MatlabBuild {
                     .stdout(listener);
 
             // Copy runner for Windows platform in workspace.
-            copyFileInWorkspace("win64\\run-matlab-command.exe", runnerName,
+            copyFileInWorkspace("win64/run-matlab-command.exe", runnerName,
                     targetWorkspace);
         }
         return matlabLauncher;

--- a/src/main/java/com/mathworks/ci/RunMatlabCommandStep.java
+++ b/src/main/java/com/mathworks/ci/RunMatlabCommandStep.java
@@ -11,6 +11,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import com.google.common.collect.ImmutableSet;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -23,17 +24,21 @@ import hudson.Util;
 public class RunMatlabCommandStep extends Step {
     
     private String command;
-    private String startupOptions;
+    private String startupOptions = "";
 
     @DataBoundConstructor
-    public RunMatlabCommandStep(String command, String startupOptions) {
+    public RunMatlabCommandStep(String command) {
         this.command = command;
-        this.startupOptions = startupOptions;
     }
 
 
     public String getCommand() {
         return this.command;
+    }
+
+    @DataBoundSetter
+    public void setStartupOptions(String startupOptions) {
+        this.startupOptions = startupOptions;
     }
 
     public String getStartupOptions() {

--- a/src/test/java/com/mathworks/ci/RunMatlabCommandStepTester.java
+++ b/src/test/java/com/mathworks/ci/RunMatlabCommandStepTester.java
@@ -20,8 +20,8 @@ import hudson.model.TaskListener;
 
 public class RunMatlabCommandStepTester extends RunMatlabCommandStep {
     @DataBoundConstructor
-    public RunMatlabCommandStepTester(String command, String startupOptions) {
-        super(command, startupOptions);
+    public RunMatlabCommandStepTester(String command) {
+        super(command);
     }
     
     @Override


### PR DESCRIPTION
…or certain versions of Jenkins.

Pull request is WIP, verified change fixes issue for recent versions of Jenkins but need to double check that it doesn't break things on older versions.