### PR TITLE
Addressed  Jenkins security issues

### DIFF
--- a/src/main/java/com/mathworks/ci/MatlabBuilder.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilder.java
@@ -8,6 +8,7 @@ package com.mathworks.ci;
  * nikhil.bhoski@mathworks.in Date : 28/03/2018 (Initial draft)
  */
 
+import hudson.model.Item;
 import hudson.security.Permission;
 import java.io.File;
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.util.function.Function;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.ArrayUtils;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -151,8 +153,11 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
          */
 
         @POST
-        public FormValidation doCheckMatlabRoot(@QueryParameter String matlabRoot) {
-            Jenkins.get().checkPermission(Permission.CONFIGURE);
+        public FormValidation doCheckMatlabRoot(@QueryParameter String matlabRoot, @AncestorInPath Item item) {
+            if (item == null) {
+                return FormValidation.ok();
+            }
+            item.checkPermission(Item.CONFIGURE);
             setMatlabRoot(matlabRoot);
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();

--- a/src/main/java/com/mathworks/ci/MatlabBuilder.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilder.java
@@ -150,6 +150,7 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
 
 
         public FormValidation doCheckMatlabRoot(@QueryParameter String matlabRoot) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             setMatlabRoot(matlabRoot);
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();

--- a/src/main/java/com/mathworks/ci/MatlabBuilder.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilder.java
@@ -151,7 +151,7 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
 
         @POST
         public FormValidation doCheckMatlabRoot(@QueryParameter String matlabRoot) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
             setMatlabRoot(matlabRoot);
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();

--- a/src/main/java/com/mathworks/ci/MatlabBuilder.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilder.java
@@ -8,6 +8,7 @@ package com.mathworks.ci;
  * nikhil.bhoski@mathworks.in Date : 28/03/2018 (Initial draft)
  */
 
+import hudson.security.Permission;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -151,7 +152,7 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
 
         @POST
         public FormValidation doCheckMatlabRoot(@QueryParameter String matlabRoot) {
-            Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
+            Jenkins.get().checkPermission(Permission.CONFIGURE);
             setMatlabRoot(matlabRoot);
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();

--- a/src/main/java/com/mathworks/ci/MatlabBuilder.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilder.java
@@ -43,6 +43,7 @@ import hudson.util.FormValidation.Kind;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.verb.POST;
 
 public class MatlabBuilder extends Builder implements SimpleBuildStep {
 
@@ -148,7 +149,7 @@ public class MatlabBuilder extends Builder implements SimpleBuildStep {
          * descriptor class.
          */
 
-
+        @POST
         public FormValidation doCheckMatlabRoot(@QueryParameter String matlabRoot) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             setMatlabRoot(matlabRoot);

--- a/src/main/java/com/mathworks/ci/MatlabReleaseInfo.java
+++ b/src/main/java/com/mathworks/ci/MatlabReleaseInfo.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.collections.MapUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -25,6 +26,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
+import org.xml.sax.SAXException;
 
 public class MatlabReleaseInfo {
     private FilePath matlabRoot;
@@ -82,6 +84,15 @@ public class MatlabReleaseInfo {
                 FilePath versionFile = new FilePath(this.matlabRoot, VERSION_INFO_FILE);
                 if(versionFile.exists()) {
                     DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+                    String FEATURE = null;
+                    try{
+                        FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+                        dbFactory.setFeature(FEATURE, true);
+                        dbFactory.setXIncludeAware(false);
+
+                    } catch (ParserConfigurationException e) {
+                        throw new MatlabVersionNotFoundException("Error parsing verify if XML is valid", e);
+                    }
                     DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
                     Document doc = dBuilder.parse(versionFile.read());
                     

--- a/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
+++ b/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
@@ -141,7 +141,7 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
          */
         @POST
         public FormValidation doCheckMatlabRootFolder(@QueryParameter String matlabRootFolder) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();
             listOfCheckMethods.add(chkMatlabEmpty);

--- a/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
+++ b/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
@@ -8,6 +8,7 @@ package com.mathworks.ci;
  *
  */
 
+import hudson.security.Permission;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -141,7 +142,7 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
          */
         @POST
         public FormValidation doCheckMatlabRootFolder(@QueryParameter String matlabRootFolder) {
-            Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
+            Jenkins.get().checkPermission(Permission.CONFIGURE);
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();
             listOfCheckMethods.add(chkMatlabEmpty);

--- a/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
+++ b/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 
 import hudson.matrix.MatrixProject;
 import hudson.model.Computer;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -139,6 +140,7 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
          */
 
         public FormValidation doCheckMatlabRootFolder(@QueryParameter String matlabRootFolder) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();
             listOfCheckMethods.add(chkMatlabEmpty);

--- a/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
+++ b/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
@@ -8,6 +8,7 @@ package com.mathworks.ci;
  *
  */
 
+import hudson.model.Item;
 import hudson.security.Permission;
 import java.io.File;
 import java.io.IOException;
@@ -19,6 +20,7 @@ import java.util.function.Function;
 import hudson.matrix.MatrixProject;
 import hudson.model.Computer;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -141,8 +143,11 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
          * descriptor class.
          */
         @POST
-        public FormValidation doCheckMatlabRootFolder(@QueryParameter String matlabRootFolder) {
-            Jenkins.get().checkPermission(Permission.CONFIGURE);
+        public FormValidation doCheckMatlabRootFolder(@QueryParameter String matlabRootFolder, @AncestorInPath Item item) {
+            if (item == null) {
+                return FormValidation.ok();
+            }
+            item.checkPermission(Item.CONFIGURE);
             List<Function<String, FormValidation>> listOfCheckMethods =
                     new ArrayList<Function<String, FormValidation>>();
             listOfCheckMethods.add(chkMatlabEmpty);

--- a/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
+++ b/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
@@ -32,6 +32,7 @@ import hudson.model.TaskListener;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.FormValidation;
 import jenkins.tasks.SimpleBuildWrapper;
+import org.kohsuke.stapler.verb.POST;
 
 public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
 
@@ -138,7 +139,7 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
          * these methods are used to perform basic validation on UI elements associated with this
          * descriptor class.
          */
-
+        @POST
         public FormValidation doCheckMatlabRootFolder(@QueryParameter String matlabRootFolder) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             List<Function<String, FormValidation>> listOfCheckMethods =

--- a/src/main/resources/com/mathworks/ci/MatlabBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/MatlabBuilder/config.jelly
@@ -4,7 +4,7 @@
  <font color="red">Using this build step is not recommended and will be removed in a feature release. Use “Run MATLAB Tests” or “Run MATLAB Command” instead.</font>   
  <f:section>
 	  <f:entry title="MATLAB root " field="matlabRoot">
-	        <f:textbox disabled="disabled"/>
+	        <f:textbox disabled="disabled" checkMethod="post" />
 	  </f:entry> 
 </f:section>
 <f:dropdownDescriptorSelector title="Test mode" field="testRunTypeList" descriptors="${descriptor.testRunTypeDescriptor}" selected="${instance.testRunTypeList}" disabled="true"/>

--- a/src/main/resources/com/mathworks/ci/UseMatlabVersionBuildWrapper/config.jelly
+++ b/src/main/resources/com/mathworks/ci/UseMatlabVersionBuildWrapper/config.jelly
@@ -18,7 +18,7 @@
 				<j:choose>
 					<j:when test="${loop.last}">
 						<f:entry title="MATLAB root: " field="matlabRootFolder">
-							<f:textbox/>
+							<f:textbox checkMethod="post"/>
 						</f:entry>
 					</j:when>
 				</j:choose>


### PR DESCRIPTION
We have Jenkins issue opened with some security vulnerabilities  as per the suggestions this PR contains the fix. 
* ReproductionStep
Add a dangerous XML called VersionInfo.xml into the Jenkins controller file system using an "Execute Shell” build step.
Payload:
echo '
<!DOCTYPE foo [ <!ENTITY xxe SYSTEM "file://<CustomPath>"> ]>
<MathWorks_version_info>
<release>
&xxe;
</release>
</MathWorks_version_info>' > VersionInfo.xml
Add an “Archive the artifacts” post build step
**/*.xml
Build the Job
Go into the "configure job"
Check “Use MATLAB version" under the "Build Environment" section.
Fill the "MATLAB root" with ./work/jobs/<JobName>/builds/<BuildNumber>/archive/
OR
Navigate to:
<JenkinsInstanceURL>/descriptorByName/com.mathworks.ci.UseMatlabVersionBuildWrapper/checkMatlabRootFolder?matlabRootFolder=./work/jobs/<JobName>/builds/<BuildNumber>/archive/