### PR TITLE
Patch fix for file error issue

### DIFF
--- a/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
@@ -9,7 +9,7 @@ classdef BuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
             [fID, msg] = fopen(fullfile(getenv("WORKSPACE"),".matlab/buildArtifact.json"), "w");
 
             if fID == -1
-                warning('ciplugins:jenkins:BuildReportPlugin:UnableToOpenFile','Could not open a file for Jenkins build result table due to: %s', msg);
+                warning("ciplugins:jenkins:BuildReportPlugin:UnableToOpenFile","Could not open a file for Jenkins build result table due to: %s", msg);
             else
                 closeFile = onCleanup(@()fclose(fID));
                 taskDetails = struct();
@@ -21,8 +21,8 @@ classdef BuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
                     taskDetails(idx).duration = string(pluginData.TaskResults(idx).Duration);
                 end
                 a = struct("taskDetails",taskDetails);
-                s = jsonencode(a,"PrettyPrint",true);
-                fprintf(fID, '%s',s);
+                s = jsonencode(a,PrettyPrint=true);
+                fprintf(fID, "%s",s);
             end
         end
     end

--- a/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
@@ -6,26 +6,24 @@ classdef BuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
 
         function runTaskGraph(plugin, pluginData)
             runTaskGraph@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
-            [fID, msg] = fopen(fullfile(getenv("WORKSPACE"),'.matlab/buildArtifact.json'), 'w');
+            [fID, msg] = fopen(fullfile(pwd,'buildArtifact.json'), 'w');
 
             if fID == -1
                 warning('BuildTool:artifactFileWarnning','Could not open a file for Jenkins build result table due to: %s', msg);
-                fID = 1;
+            else
+                taskDetails = struct();
+                for idx = 1:numel(pluginData.TaskResults)
+                    taskDetails(idx).name = pluginData.TaskResults(idx).Name;
+                    taskDetails(idx).description = pluginData.TaskGraph.Tasks(idx).Description;
+                    taskDetails(idx).failed = pluginData.TaskResults(idx).Failed;
+                    taskDetails(idx).skipped = pluginData.TaskResults(idx).Skipped;
+                    taskDetails(idx).duration = string(pluginData.TaskResults(idx).Duration);
+               end
+               a = struct("taskDetails",taskDetails);
+               s = jsonencode(a,"PrettyPrint",true);
+               fprintf(fID, '%s',s);
+               fclose(fID);
             end
-
-            taskDetails = struct();
-            for idx = 1:numel(pluginData.TaskResults)
-                taskDetails(idx).name = pluginData.TaskResults(idx).Name;
-                taskDetails(idx).description = pluginData.TaskGraph.Tasks(idx).Description;
-                taskDetails(idx).failed = pluginData.TaskResults(idx).Failed;
-                taskDetails(idx).skipped = pluginData.TaskResults(idx).Skipped;
-                taskDetails(idx).duration = string(pluginData.TaskResults(idx).Duration);
-            end
-            a = struct("taskDetails",taskDetails);
-            s = jsonencode(a,"PrettyPrint",true);
-            fprintf(fID, '%s',s);
-            fclose(fID);
         end
-
     end
 end

--- a/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
@@ -6,7 +6,13 @@ classdef BuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
 
         function runTaskGraph(plugin, pluginData)
             runTaskGraph@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
-            fID = fopen(fullfile(getenv("WORKSPACE"),'.matlab/buildArtifact.json'), 'w');
+            [fID, msg] = fopen(fullfile(getenv("WORKSPACE"),'.matlab/buildArtifact.json'), 'w');
+
+            if fID == -1
+                warning('BuildTool:artifactFileWarnning','Could not open a file for Jenkins build result table due to: %s', msg);
+                fID = 1;
+            end
+
             taskDetails = struct();
             for idx = 1:numel(pluginData.TaskResults)
                 taskDetails(idx).name = pluginData.TaskResults(idx).Name;

--- a/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
@@ -6,7 +6,7 @@ classdef BuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
 
         function runTaskGraph(plugin, pluginData)
             runTaskGraph@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
-            [fID, msg] = fopen(fullfile(pwd,'buildArtifact.json'), 'w');
+            [fID, msg] = fopen(fullfile(getenv("WORKSPACE"),'.matlab/buildArtifact.json'), 'w');
 
             if fID == -1
                 warning('BuildTool:artifactFileWarnning','Could not open a file for Jenkins build result table due to: %s', msg);

--- a/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
@@ -6,11 +6,12 @@ classdef BuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
 
         function runTaskGraph(plugin, pluginData)
             runTaskGraph@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
-            [fID, msg] = fopen(fullfile(getenv("WORKSPACE"),'.matlab/buildArtifact.json'), 'w');
+            [fID, msg] = fopen(fullfile(getenv("WORKSPACE"),".matlab/buildArtifact.json"), "w");
 
             if fID == -1
-                warning('BuildTool:artifactFileWarnning','Could not open a file for Jenkins build result table due to: %s', msg);
+                warning('ciplugins:jenkins:BuildReportPlugin:UnableToOpenFile','Could not open a file for Jenkins build result table due to: %s', msg);
             else
+                closeFile = onCleanup(@()fclose(fID));
                 taskDetails = struct();
                 for idx = 1:numel(pluginData.TaskResults)
                     taskDetails(idx).name = pluginData.TaskResults(idx).Name;
@@ -22,7 +23,6 @@ classdef BuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
                 a = struct("taskDetails",taskDetails);
                 s = jsonencode(a,"PrettyPrint",true);
                 fprintf(fID, '%s',s);
-                fclose(fID);
             end
         end
     end

--- a/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
@@ -18,11 +18,11 @@ classdef BuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
                     taskDetails(idx).failed = pluginData.TaskResults(idx).Failed;
                     taskDetails(idx).skipped = pluginData.TaskResults(idx).Skipped;
                     taskDetails(idx).duration = string(pluginData.TaskResults(idx).Duration);
-               end
-               a = struct("taskDetails",taskDetails);
-               s = jsonencode(a,"PrettyPrint",true);
-               fprintf(fID, '%s',s);
-               fclose(fID);
+                end
+                a = struct("taskDetails",taskDetails);
+                s = jsonencode(a,"PrettyPrint",true);
+                fprintf(fID, '%s',s);
+                fclose(fID);
             end
         end
     end

--- a/src/main/resources/com/mathworks/ci/BuildArtifactAction/summary.jelly
+++ b/src/main/resources/com/mathworks/ci/BuildArtifactAction/summary.jelly
@@ -9,7 +9,7 @@
     <p><a href="buildresults">MATLAB Build Results</a></p>
     <span class="${pst.cssClass}">
       <j:if test="${it.totalCount == 0}">
-        <font color="#EF2929"><h5>Unable to run a MATLAB build. </h5></font>
+        <font color="#EF2929"><h5>Unable to generate build artifact. </h5></font>
       </j:if>
     </span>
     <p><b>Tasks run: <font color="Blue">${it.totalCount}</font></b></p>

--- a/src/main/resources/com/mathworks/ci/BuildArtifactAction/summary.jelly
+++ b/src/main/resources/com/mathworks/ci/BuildArtifactAction/summary.jelly
@@ -9,7 +9,7 @@
     <p><a href="buildresults">MATLAB Build Results</a></p>
     <span class="${pst.cssClass}">
       <j:if test="${it.totalCount == 0}">
-        <font color="#EF2929"><h5>Unable to generate build artifact. </h5></font>
+        <font color="#EF2929"><h5>Unable to generate a build artifact. </h5></font>
       </j:if>
     </span>
     <p><b>Tasks run: <font color="Blue">${it.totalCount}</font></b></p>


### PR DESCRIPTION
This is patch fix for issue reported by Braess Hennings as detailed below. 
<details><summary>Details</summary>
<p>

In various  projects the underlying jobs failed with the following error message:

** Finished buildApp

** Closed project 'SignalManagement'

{Error using fprintf
Invalid file identifier. Use fopen to generate a valid file identifier.

Error in ciplugins.jenkins.BuildReportPlugin/runTaskGraph (line 20)
            fprintf(fID, '%s',s);

Error in matlab.buildtool.BuildRunner/evaluateMethodOnPlugins (line 256)
            [varargout{1:nargout}] = plugin.(methodName)(pluginData);

Error in matlab.buildtool.BuildRunner/run (line 222)
            runner.evaluateMethodOnPlugins("runTaskGraph", runner.PluginData.runTaskGraph);

Error in buildtool (line 39)
    result = runner.run(plan, taskName, taskArgs, runArgs{:});

Error in build_ovChyDDU (line 2)
buildtool buildApp("/AppGeneratorOutput", "SignalManager", "SignalManagerApp.mlapp", false)
} 
ERROR: MATLAB error Exit Status: 0x00000001
exit status 1
[Pipeline] }
[Pipeline] // dir
[Pipeline] }
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 7c7e63c5-6513-4c16-a06c-87c132804be5
com.mathworks.ci.MatlabExecutionException: Received a nonzero exit code 1 while trying to run MATLAB.
                    at com.mathworks.ci.MatlabBuildStepExecution.run(MatlabBuildStepExecution.java:64)
                    at com.mathworks.ci.MatlabBuildStepExecution.run(MatlabBuildStepExecution.java:22)
                    at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
                    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
                    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
                    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
                    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
                    at java.base/java.lang.Thread.run(Thread.java:829)
[Pipeline] // catchError



</p>
</details> .

* The fix checks the fopen() return value and issue a warning() to avoid build failure. 
* This fix does not provide full solution for the issue and we need to further review this issue in detail.
* This fix will just unblock our users to run Build without any failures due to our plugin changes.

Regards
Nikhil 
