### PR TITLE
Fixed issue #320

### DIFF
--- a/src/main/java/com/mathworks/ci/BuildArtifactAction.java
+++ b/src/main/java/com/mathworks/ci/BuildArtifactAction.java
@@ -21,16 +21,14 @@ import org.json.simple.parser.ParseException;
 
 public class BuildArtifactAction implements Action {
     private Run<?, ?> build;
-    private FilePath workspace;
     private int totalCount;
     private int skipCount;
     private int failCount;
     private static final String ROOT_ELEMENT = "taskDetails";
     private static final String BUILD_ARTIFACT_FILE = "buildArtifact.json";
 
-    public BuildArtifactAction(Run<?, ?> build, FilePath workspace) {
+    public BuildArtifactAction(Run<?, ?> build) {
         this.build = build;
-        this.workspace = workspace;
 
         // Setting the counts of task when Action is created.
         try{
@@ -130,9 +128,6 @@ public class BuildArtifactAction implements Action {
         this.build = owner;
     }
 
-    public FilePath getWorkspace() {
-        return this.workspace;
-    }
 
     private void setCounts() throws InterruptedException, ParseException {
         List<BuildArtifactData> artifactData = new ArrayList<BuildArtifactData>();

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
@@ -95,7 +95,7 @@ public class RunMatlabBuildAction {
                         + "buildArtifact.json"));
             jsonFile.copyTo(rootLocation);
             jsonFile.delete();
-            build.addAction(new BuildArtifactAction(build, this.params.getWorkspace()));
+            build.addAction(new BuildArtifactAction(build));
         }
     }
 }

--- a/src/test/java/integ/com/mathworks/ci/BuildArtifactActionTest.java
+++ b/src/test/java/integ/com/mathworks/ci/BuildArtifactActionTest.java
@@ -71,7 +71,7 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyBuildArtifactsReturned() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
@@ -87,7 +87,7 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyFailedCount() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
@@ -103,7 +103,7 @@ public class BuildArtifactActionTest {
     @Test
     public void verifySkipCount() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
@@ -118,7 +118,7 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyDurationIsAccurate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
@@ -133,7 +133,7 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyTaskDescriptionIsAccurate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
@@ -148,7 +148,7 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyTaskNameIsAccurate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
@@ -165,7 +165,7 @@ public class BuildArtifactActionTest {
         FreeStyleBuild build = getFreestyleBuild();
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         Assert.assertEquals("Total task count is not correct",1,ac.getTotalCount());
     }
 
@@ -179,7 +179,7 @@ public class BuildArtifactActionTest {
         FreeStyleBuild build = getFreestyleBuild();
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         Assert.assertEquals("Total task count is not correct",3,ac.getTotalCount());
     }
 
@@ -193,7 +193,7 @@ public class BuildArtifactActionTest {
         FreeStyleBuild build = getFreestyleBuild();
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         Assert.assertEquals("Total task count is not correct",3,ac.getTotalCount());
         Assert.assertEquals("Total task failed count is not correct",1,ac.getFailCount());
     }
@@ -207,7 +207,7 @@ public class BuildArtifactActionTest {
         FreeStyleBuild build = getFreestyleBuild();
         FilePath artifactRoot = new FilePath(build.getRootDir());
         copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
-        BuildArtifactAction ac = new BuildArtifactAction(build,build.getWorkspace());
+        BuildArtifactAction ac = new BuildArtifactAction(build);
         Assert.assertEquals("Total task count is not correct",3,ac.getTotalCount());
         Assert.assertEquals("Total task skip count is not correct",1,ac.getSkipCount());
     }


### PR DESCRIPTION
This PR closes #320 
The PR includes the fix for the warning messages displayed under Jenkins server logs once runMATLABBuild` is executed. 
* Issue was `FilePath` object was getting serialised as mentioned in warning logs below 
#### Fix
* Remove Unwanted `FailePath` object from `BuildArtifactAction` file.

#### Warning shown under Jenkins server

```
May 27, 2024 1:14:42 PM WARNING hudson.FilePath _getChannelForSerialization
A FilePath object is being serialized when it should not be, indicating a bug in a plugin. See https://www.jenkins.io/redirect/filepath-serialization for details.
[java.io](http://java.io/).NotSerializableException: The calling thread Thread[Handling GET /job/free/ from 172.19.148.116 : Jetty (winstone)-20 Job/index.jelly AbstractProject/sidepanel.jelly HistoryWidget/index.jelly,5,main] has no associated channel. The current object null is interface org.jenkinsci.remoting.SerializableOnlyOverRemoting, but it is likely being serialized/deserialized without the channel
	atMay 27, 2024 1:14:42 PM WARNING hudson.FilePath _getChannelForSerialization
A FilePath object is being serialized when it should not be, indicating a bug in a plugin. See https://www.jenkins.io/redirect/filepath-serialization for details.
[java.io](http://java.io/).NotSerializableException: The calling thread Thread[Handling GET /job/free/ from 172.19.148.116 : Jetty (winstone)-20 Job/index.jelly AbstractProject/sidepanel.jelly HistoryWidget/index.jelly,5,main] has no associated channel. The current object null is interface org.jenkinsci.remoting.SerializableOnlyOverRemoting, but it is likely being serialized/deserialized without the channel
```
