### PR TITLE
Update run-matlab-command version, add maca support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/glnxa64/run-matlab-command</url>
+							<url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/glnxa64/run-matlab-command</url>
 							<unpack>false</unpack>
 							<outputDirectory>${basedir}/src/main/resources/glnxa64</outputDirectory>
 							<skipCache>true</skipCache>
@@ -132,15 +132,29 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>get-matlab-runner-mac</id>
+						<id>get-matlab-runner-maci</id>
 						<phase>validate</phase>
 						<goals>
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/maci64/run-matlab-command</url>
+							<url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/maci64/run-matlab-command</url>
 							<unpack>false</unpack>
 							<outputDirectory>${basedir}/src/main/resources/maci64</outputDirectory>
+							<skipCache>true</skipCache>
+							<overwrite>true</overwrite>
+						</configuration>
+					</execution>
+					<execution>
+						<id>get-matlab-runner-maca</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/maca64/run-matlab-command</url>
+							<unpack>false</unpack>
+							<outputDirectory>${basedir}/src/main/resources/maca64</outputDirectory>
 							<skipCache>true</skipCache>
 							<overwrite>true</overwrite>
 						</configuration>
@@ -152,7 +166,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/win64/run-matlab-command.exe</url>
+							<url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/win64/run-matlab-command.exe</url>
 							<unpack>false</unpack>
 							<outputDirectory>${basedir}/src/main/resources/win64</outputDirectory>
 							<skipCache>true</skipCache>

--- a/src/main/java/com/mathworks/ci/utilities/MatlabCommandRunner.java
+++ b/src/main/java/com/mathworks/ci/utilities/MatlabCommandRunner.java
@@ -68,6 +68,8 @@ public class MatlabCommandRunner {
      */
     public void runMatlabCommand(String command) throws IOException, InterruptedException, MatlabExecutionException {
 
+        System.err.println("START");
+
         this.params.getTaskListener().getLogger()
             .println("\n#################### Starting command output ####################");
 
@@ -191,15 +193,24 @@ public class MatlabCommandRunner {
         if (launcher.isUnix()) {
             // Run uname to check if we're on Linux
             ByteArrayOutputStream kernelStream = new ByteArrayOutputStream();
+
+            ArgumentListBuilder args = new ArgumentListBuilder();
+            args.add("uname");
+            args.add("-s");
+            args.add("-m");
+
             launcher.launch()
-                .cmds("uname")
-                .masks(true)
+                .cmds(args)
+                .masks(true, true, true)
                 .stdout(kernelStream)
                 .join();
 
             String runnerSource;
-            if (kernelStream.toString("UTF-8").contains("Linux")) {
+            String kernelArch = kernelStream.toString("UTF-8");
+            if (kernelArch.contains("Linux")) {
                 runnerSource = "glnxa64/run-matlab-command";
+            } else if (kernelArch.contains("arm64")) {
+                runnerSource = "maca64/run-matlab-command"; 
             } else {
                 runnerSource = "maci64/run-matlab-command";
             }

--- a/src/test/java/unit/com/mathworks/ci/utilities/MatlabCommandRunnerTest.java
+++ b/src/test/java/unit/com/mathworks/ci/utilities/MatlabCommandRunnerTest.java
@@ -66,9 +66,9 @@ public class MatlabCommandRunnerTest {
 
        doReturn(false).when(launcher).isUnix();
        when(launcher.launch()).thenReturn(procStarter);
-       when(procStarter.cmds(anyString())).thenReturn(procStarter);
        when(procStarter.cmds(any(ArgumentListBuilder.class))).thenReturn(procStarter);
-       when(procStarter.masks(anyBoolean())).thenReturn(procStarter);
+       when(procStarter.masks(anyBoolean(), anyBoolean(), anyBoolean()))
+           .thenReturn(procStarter);
        when(procStarter.envs(any(EnvVars.class))).thenReturn(procStarter);
        doReturn(procStarter).when(procStarter)
            .stdout(any(OutputStream.class));
@@ -99,7 +99,23 @@ public class MatlabCommandRunnerTest {
     }
 
     @Test
-    public void prepareRunnerExecutableLinux() throws IOException, InterruptedException {
+    public void prepareRunnerExecutableMaci() throws IOException, InterruptedException {
+        runner = new MatlabCommandRunner(params);
+
+        doReturn(true).when(launcher).isUnix();
+
+        FilePath f = runner.prepareRunnerExecutable();
+
+        Assert.assertTrue(f.exists());
+        Assert.assertEquals(
+                runner.getTempFolder().getRemote() 
+                + File.separator
+                + "run-matlab-command",
+                f.getRemote());
+    }
+
+    @Test
+    public void prepareRunnerExecutableMaca() throws IOException, InterruptedException {
         runner = new MatlabCommandRunner(params);
 
         doReturn(true).when(launcher).isUnix();    
@@ -109,7 +125,7 @@ public class MatlabCommandRunnerTest {
                        Object[] args = invocation.getArguments();
                        OutputStream s = (OutputStream)args[0];
 
-                       String tag = "Linux";
+                       String tag = "arm64";
                        s.write(tag.getBytes());
                     return procStarter;
                    }
@@ -126,10 +142,21 @@ public class MatlabCommandRunnerTest {
     }
 
     @Test
-    public void prepareRunnerExecutableMac() throws IOException, InterruptedException {
+    public void prepareRunnerExecutableLinux() throws IOException, InterruptedException {
         runner = new MatlabCommandRunner(params);
 
-        doReturn(true).when(launcher).isUnix();
+        doReturn(true).when(launcher).isUnix();    
+        when(procStarter.stdout(any(OutputStream.class))).thenAnswer(
+               new Answer() {
+                   public Object answer(InvocationOnMock invocation) throws IOException {
+                       Object[] args = invocation.getArguments();
+                       OutputStream s = (OutputStream)args[0];
+
+                       String tag = "Linux";
+                       s.write(tag.getBytes());
+                    return procStarter;
+                   }
+               });
 
         FilePath f = runner.prepareRunnerExecutable();
 


### PR DESCRIPTION
Updated the plugin to contain the ARM version of run-matlab-command to support maca64. Fixes issue [328](https://github.com/mathworks/jenkins-matlab-plugin/issues/328)