### PR TITLE
Improve teardown

### DIFF
--- a/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
@@ -81,6 +81,14 @@ public class RunMatlabBuildAction {
             throw(e);
         } finally {
             annotator.forceEol();
+
+            try {
+                this.runner.removeTempFolder();
+            } catch (Exception e) {
+                // Don't want to override more important error
+                // thrown in catch block
+                System.err.println(e.toString());
+            }
         }
 
         // Handle build result

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabCommandAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabCommandAction.java
@@ -31,6 +31,14 @@ public class RunMatlabCommandAction {
             this.params.getTaskListener().getLogger()
                 .println(e.getMessage());
             throw(e);
-        } 
+        } finally {
+            try {
+                this.runner.removeTempFolder();
+            } catch (Exception e) {
+                // Don't want to override more important error
+                // thrown in catch block
+                System.err.println(e.toString());
+            }
+        }
     }
 }

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabTestsAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabTestsAction.java
@@ -50,7 +50,15 @@ public class RunMatlabTestsAction {
                 .getLogger()
                 .println(e.getMessage());
             throw(e);
-        }
+        } finally {
+            try {
+                this.runner.removeTempFolder();
+            } catch (Exception e) {
+                // Don't want to override more important error
+                // thrown in catch block
+                System.err.println(e.toString());
+            }
+        } 
     }
 
     private String singleQuotify(String in) {

--- a/src/main/java/com/mathworks/ci/utilities/MatlabCommandRunner.java
+++ b/src/main/java/com/mathworks/ci/utilities/MatlabCommandRunner.java
@@ -48,17 +48,6 @@ public class MatlabCommandRunner {
 
         // Create temp folder
         this.tempFolder = matlabFolder.createTempDir("tempDir", null);
-        
-        // If we hit an error during shutdown while cleaning up
-        // there's not too much that we can do.
-        Runtime.getRuntime().addShutdownHook(
-                new Thread(() -> {
-                    try {
-                        tempFolder.deleteRecursive();
-                    } catch(Exception e) {
-                        System.err.println(e.toString());
-                    }
-                }));
     }
 
     /** 
@@ -67,9 +56,6 @@ public class MatlabCommandRunner {
      * @param command The command to run
      */
     public void runMatlabCommand(String command) throws IOException, InterruptedException, MatlabExecutionException {
-
-        System.err.println("START");
-
         this.params.getTaskListener().getLogger()
             .println("\n#################### Starting command output ####################");
 
@@ -157,6 +143,12 @@ public class MatlabCommandRunner {
 
     public FilePath getTempFolder() {
         return tempFolder;
+    }
+
+    public void removeTempFolder() throws IOException, InterruptedException {
+        if (tempFolder.exists()) {
+            tempFolder.deleteRecursive();
+        }
     }
 
     /**

--- a/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
+++ b/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
@@ -168,4 +168,11 @@ public class RunMatlabBuildActionTest {
         // Should have copied file to root dir
         assertTrue(new File(tmp, "buildArtifact.json").exists());
     }
+
+    @Test
+    public void shouldRemoveTempFolder() throws IOException, InterruptedException, MatlabExecutionException {
+        action.run();
+
+        verify(runner).removeTempFolder();
+    }
 }

--- a/src/test/java/unit/com/mathworks/ci/actions/RunMatlabCommandActionTest.java
+++ b/src/test/java/unit/com/mathworks/ci/actions/RunMatlabCommandActionTest.java
@@ -66,4 +66,11 @@ public class RunMatlabCommandActionTest {
             assertEquals(12, e.getExitCode());
         };
     }
+
+    @Test
+    public void shouldRemoveTempFolder() throws IOException, InterruptedException, MatlabExecutionException {
+        action.run();
+
+        verify(runner).removeTempFolder();
+    }
 }

--- a/src/test/java/unit/com/mathworks/ci/actions/RunMatlabTestsActionTest.java
+++ b/src/test/java/unit/com/mathworks/ci/actions/RunMatlabTestsActionTest.java
@@ -170,4 +170,11 @@ public class RunMatlabTestsActionTest {
             assertEquals(12, e.getExitCode());
         };
     }
+
+    @Test
+    public void shouldRemoveTempFolder() throws IOException, InterruptedException, MatlabExecutionException {
+        action.run();
+
+        verify(runner).removeTempFolder();
+    }
 }

--- a/src/test/java/unit/com/mathworks/ci/utilities/MatlabCommandRunnerTest.java
+++ b/src/test/java/unit/com/mathworks/ci/utilities/MatlabCommandRunnerTest.java
@@ -99,6 +99,22 @@ public class MatlabCommandRunnerTest {
     }
 
     @Test
+    public void removeTempFolderDeletesContents() throws IOException, InterruptedException {
+        runner = new MatlabCommandRunner(params);
+
+        FilePath t = runner.getTempFolder();
+        FilePath f = runner.copyFileToTempFolder("testcontent.txt", "target.txt");
+
+        Assert.assertTrue(t.exists());
+        Assert.assertTrue(f.exists());
+
+        runner.removeTempFolder();
+
+        Assert.assertFalse(t.exists());
+        Assert.assertFalse(f.exists());
+    }
+
+    @Test
     public void prepareRunnerExecutableMaci() throws IOException, InterruptedException {
         runner = new MatlabCommandRunner(params);
 


### PR DESCRIPTION
Not a fix for issue [332](https://github.com/mathworks/jenkins-matlab-plugin/issues/332). I still need to think through what the consequences for having the temporary scripts self destruct would be. E.g. would we be resilient to page faults at high load, does this severely hinder debuggability, etc...

However, this should slightly improve performance as now the `MatlabCommandRunner` objects can be cleaned up before JVM shutdown. Especially for very long running Jenkins servers / agents this should be an improvement.