### PR TITLE
Switch to using a temporary directory on the agent external to the WS.

### DIFF
--- a/src/main/java/com/mathworks/ci/BuildArtifactAction.java
+++ b/src/main/java/com/mathworks/ci/BuildArtifactAction.java
@@ -60,7 +60,7 @@ public class BuildArtifactAction implements Action {
 
     public List<BuildArtifactData> getBuildArtifact() throws ParseException, InterruptedException, IOException {
         List<BuildArtifactData> artifactData = new ArrayList<BuildArtifactData>();
-        FilePath fl = new FilePath(new File(build.getRootDir().getAbsolutePath() + "/" + BUILD_ARTIFACT_FILE));
+        FilePath fl = new FilePath(new File(build.getRootDir().getAbsolutePath(), BUILD_ARTIFACT_FILE));
         try (InputStreamReader reader = new InputStreamReader(new FileInputStream(new File(fl.toURI())), "UTF-8")) {
             Object obj = new JSONParser().parse(reader);
             JSONObject jo = (JSONObject) obj;

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
@@ -78,20 +78,6 @@ public class RunMatlabBuildAction {
 
         try {
             runner.runMatlabCommand(command);
-
-            // Handle build result
-            Run<?,?> build = this.params.getBuild();
-            FilePath jsonFile = new FilePath(runner.getTempFolder(), "buildArtifact.json");
-            if (jsonFile.exists()) {
-                FilePath rootLocation = new FilePath(
-                        new File(
-                            build.getRootDir().getAbsolutePath(),
-                            "buildArtifact.json")
-                        );
-                jsonFile.copyTo(rootLocation);
-                jsonFile.delete();
-                build.addAction(new BuildArtifactAction(build));
-            }
         } catch (Exception e) {
             this.params.getTaskListener().getLogger()
                 .println(e.getMessage());
@@ -100,11 +86,29 @@ public class RunMatlabBuildAction {
             annotator.forceEol();
 
             try {
-                this.runner.removeTempFolder();
+                // Handle build result
+                Run<?,?> build = this.params.getBuild();
+                FilePath jsonFile = new FilePath(runner.getTempFolder(), "buildArtifact.json");
+                if (jsonFile.exists()) {
+                    FilePath rootLocation = new FilePath(
+                            new File(
+                                build.getRootDir().getAbsolutePath(),
+                                "buildArtifact.json")
+                            );
+                    jsonFile.copyTo(rootLocation);
+                    jsonFile.delete();
+                    build.addAction(new BuildArtifactAction(build));
+                }
             } catch (Exception e) {
                 // Don't want to override more important error
                 // thrown in catch block
                 System.err.println(e.toString());
+            } finally {
+                try {
+                    this.runner.removeTempFolder();
+                } catch (Exception e) {
+                    System.err.println(e.toString());
+                }
             }
         }
     }

--- a/src/main/java/com/mathworks/ci/utilities/MatlabCommandRunner.java
+++ b/src/main/java/com/mathworks/ci/utilities/MatlabCommandRunner.java
@@ -18,6 +18,7 @@ import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.Launcher.ProcStarter;
 import hudson.model.Computer;
+import hudson.slaves.WorkspaceList;
 import hudson.util.ArgumentListBuilder;
 
 import com.mathworks.ci.Utilities;
@@ -43,11 +44,11 @@ public class MatlabCommandRunner {
         }
 
         // Create MATLAB folder
-        FilePath matlabFolder = new FilePath(workspace, ".matlab");
-        matlabFolder.mkdirs();
+        FilePath tmpRoot = WorkspaceList.tempDir(workspace);
+        tmpRoot.mkdirs();
 
         // Create temp folder
-        this.tempFolder = matlabFolder.createTempDir("tempDir", null);
+        this.tempFolder = tmpRoot.createTempDir("matlab", null);
     }
 
     /** 

--- a/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/BuildReportPlugin.m
@@ -6,8 +6,7 @@ classdef BuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
 
         function runTaskGraph(plugin, pluginData)
             runTaskGraph@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
-            [fID, msg] = fopen(fullfile(getenv("WORKSPACE"),".matlab/buildArtifact.json"), "w");
-
+            [fID, msg] = fopen(fullfile(getenv("MW_MATLAB_TEMP_FOLDER"),"buildArtifact.json"), "w");
             if fID == -1
                 warning("ciplugins:jenkins:BuildReportPlugin:UnableToOpenFile","Could not open a file for Jenkins build result table due to: %s", msg);
             else

--- a/src/test/java/integ/com/mathworks/ci/RunMatlabBuildBuilderTest.java
+++ b/src/test/java/integ/com/mathworks/ci/RunMatlabBuildBuilderTest.java
@@ -356,18 +356,4 @@ public class RunMatlabBuildBuilderTest {
 		jenkins.assertLogContains("R2018b completed", build);
 		jenkins.assertBuildStatus(Result.SUCCESS, build);
 	}
-	
-    /*
-     * Test to verify if .matlab temp folder generated in workspace.
-     */
-    @Test
-    public void verifyMATLABtmpFolderGenerated() throws Exception {
-        this.buildWrapper.setMatlabBuildWrapperContent(new MatlabBuildWrapperContent(Message.getValue("matlab.custom.location"), getMatlabroot("R2018b")));
-        project.getBuildWrappersList().add(this.buildWrapper);
-        scriptBuilder.setTasks("");
-        project.getBuildersList().add(this.scriptBuilder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
-        File matlabRunner = new File(build.getWorkspace() + File.separator + ".matlab");
-        Assert.assertTrue(matlabRunner.exists());
-    }
 }

--- a/src/test/java/integ/com/mathworks/ci/RunMatlabBuildStepTest.java
+++ b/src/test/java/integ/com/mathworks/ci/RunMatlabBuildStepTest.java
@@ -176,16 +176,4 @@ public class RunMatlabBuildStepTest {
         j.assertBuildStatus(Result.FAILURE, build);
         j.assertLogContains(String.format(Message.getValue("matlab.execution.exception.prefix"), 1), build);
     }
-    
-    /*
-     * Verify .matlab folder is generated 
-     */
-    @Test
-    public void verifyMATLABtempFolderGenerated() throws Exception {
-        project.setDefinition(
-                new CpsFlowDefinition("node { runMATLABBuild() }", true));
-
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        j.assertLogContains(".matlab", build);
-    }
 }

--- a/src/test/java/integ/com/mathworks/ci/RunMatlabCommandBuilderTest.java
+++ b/src/test/java/integ/com/mathworks/ci/RunMatlabCommandBuilderTest.java
@@ -377,18 +377,4 @@ public class RunMatlabCommandBuilderTest {
         jenkins.assertLogContains("Generating MATLAB script with content", build);
         jenkins.assertLogContains(expectedCommand, build);
     }
-    
-    /*
-     * Test to verify if .matlab temp folder generated in workspace.
-     */
-    @Test
-    public void verifyMATLABtmpFolderGenerated() throws Exception {
-        this.buildWrapper.setMatlabBuildWrapperContent(new MatlabBuildWrapperContent(Message.getValue("matlab.custom.location"), getMatlabroot("R2018b")));
-        project.getBuildWrappersList().add(this.buildWrapper);
-        scriptBuilder.setMatlabCommand("pwd");
-        project.getBuildersList().add(this.scriptBuilder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
-        File matlabRunner = new File(build.getWorkspace() + File.separator + ".matlab");
-        Assert.assertTrue(matlabRunner.exists());
-    }
 }

--- a/src/test/java/integ/com/mathworks/ci/RunMatlabCommandStepTest.java
+++ b/src/test/java/integ/com/mathworks/ci/RunMatlabCommandStepTest.java
@@ -149,18 +149,4 @@ public class RunMatlabCommandStepTest {
         j.assertLogContains(String.format(Message.getValue("matlab.execution.exception.prefix"), 1), build);
         j.assertBuildStatusSuccess(build);
     }
-    
-    /*
-     * Verify .matlab folder is generated 
-     *
-     */
-
-    @Test
-    public void verifyMATLABtempFolderGenerated() throws Exception {
-        project.setDefinition(
-                new CpsFlowDefinition("node { runMATLABCommand(command: 'pwd')}", true));
-
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        j.assertLogContains(".matlab", build);
-    }
 }

--- a/src/test/java/integ/com/mathworks/ci/RunMatlabTestsBuilderTest.java
+++ b/src/test/java/integ/com/mathworks/ci/RunMatlabTestsBuilderTest.java
@@ -485,19 +485,6 @@ public class RunMatlabTestsBuilderTest {
     }
     
     /*
-     * Test to verify if .matlab gets created in workspace.
-     */
-    @Test
-    public void verifyMATLABfolderGenerated() throws Exception {
-        this.buildWrapper.setMatlabBuildWrapperContent(new MatlabBuildWrapperContent(Message.getValue("matlab.custom.location"), getMatlabroot("R2018b")));
-        project.getBuildWrappersList().add(this.buildWrapper);
-        project.getBuildersList().add(testBuilder);
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
-        File matlabRunner = new File(build.getWorkspace() + File.separator + ".matlab");
-        Assert.assertTrue(matlabRunner.exists());
-    }
-    
-    /*
      * Test to verify Use Parallel check box present.
      */
      @Test

--- a/src/test/java/integ/com/mathworks/ci/RunMatlabTestsStepTest.java
+++ b/src/test/java/integ/com/mathworks/ci/RunMatlabTestsStepTest.java
@@ -156,18 +156,6 @@ public class RunMatlabTestsStepTest {
         j.assertLogContains(String.format(Message.getValue("matlab.execution.exception.prefix"), 1), build);
     }
     
-    /*
-     * Verify .matlab folder created 
-     */
-
-    @Test
-    public void verifyMATLABtempFolderGenerated() throws Exception {
-        project.setDefinition(new CpsFlowDefinition(
-                "node {runMATLABTests(testResultsPDF:'myresult/result.pdf')}", true));
-        WorkflowRun build = project.scheduleBuild2(0).get();
-        j.assertLogContains(".matlab", build);
-    }
-    
     /*@Integ Test
      * Verify default command options for test Filter using selectByFolder option 
      */

--- a/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
+++ b/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
@@ -152,15 +152,8 @@ public class RunMatlabBuildActionTest {
         doReturn(new FilePath(tmp)).when(runner).getTempFolder();
         doReturn(dest).when(build).getRootDir();
 
-        boolean runTimeException = false;
-        try {
-            action.run();
-        } catch (RuntimeException e) {
-            runTimeException = true;
-        }
+        action.run();
 
-        // Should throw for invalid file
-        assertTrue(runTimeException);
         // Should have deleted original file
         assertFalse(json.exists());
         // Should have copied file to root dir

--- a/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
+++ b/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
@@ -54,8 +54,6 @@ public class RunMatlabBuildActionTest {
             when(runner.getTempFolder()).thenReturn(tempFolder);
             when(tempFolder.getRemote()).thenReturn("/path/less/traveled");
 
-            when(params.getWorkspace()).thenReturn(tempFolder);
-
             when(params.getTaskListener()).thenReturn(listener);
             when(listener.getLogger()).thenReturn(out);
 
@@ -137,22 +135,22 @@ public class RunMatlabBuildActionTest {
     public void shouldNotAddActionIfNoBuildResult() throws IOException, InterruptedException, MatlabExecutionException {
         action.run();
 
-        verify(build,  never()).addAction(any(BuildArtifactAction.class));
+        verify(build, never()).addAction(any(BuildArtifactAction.class));
     }
 
     @Test
-    public void shouldCopyBuildResultsToRootAndAddsAction() throws IOException, InterruptedException, MatlabExecutionException {
+    public void shouldCopyBuildResultsToRootAndAddAction() throws IOException, InterruptedException, MatlabExecutionException {
         File tmp = Files.createTempDirectory("temp").toFile();
         tmp.deleteOnExit();
-
-        File matlab = new File(tmp, ".matlab");
-        File json = new File(matlab, "buildArtifact.json");
-
-        matlab.mkdirs();
-        json.createNewFile();
         
-        doReturn(new FilePath(tmp)).when(params).getWorkspace();
-        doReturn(tmp).when(build).getRootDir();
+        File dest = Files.createTempDirectory("dest").toFile();
+        dest.deleteOnExit();
+
+        File json = new File(tmp, "buildArtifact.json");
+        json.createNewFile();
+
+        doReturn(new FilePath(tmp)).when(runner).getTempFolder();
+        doReturn(dest).when(build).getRootDir();
 
         boolean runTimeException = false;
         try {
@@ -166,7 +164,7 @@ public class RunMatlabBuildActionTest {
         // Should have deleted original file
         assertFalse(json.exists());
         // Should have copied file to root dir
-        assertTrue(new File(tmp, "buildArtifact.json").exists());
+        assertTrue(new File(dest, "buildArtifact.json").exists());
     }
 
     @Test

--- a/src/test/java/unit/com/mathworks/ci/utilities/MatlabCommandRunnerTest.java
+++ b/src/test/java/unit/com/mathworks/ci/utilities/MatlabCommandRunnerTest.java
@@ -16,6 +16,7 @@ import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.Launcher.ProcStarter;
 import hudson.model.TaskListener;
+import hudson.slaves.WorkspaceList;
 import hudson.util.ArgumentListBuilder;
 
 import org.junit.Test;
@@ -91,8 +92,10 @@ public class MatlabCommandRunnerTest {
     public void correctTempFolderLocation() throws IOException, InterruptedException {
         runner = new MatlabCommandRunner(params);
         FilePath tmp = runner.getTempFolder();
-        FilePath expected = new FilePath(new File(tempDir.getRoot(), ".matlab"));
+
+        FilePath expected = WorkspaceList.tempDir(new FilePath(tempDir.getRoot()));
         
+        Assert.assertTrue(tmp.exists());
         Assert.assertThat(
                 tmp.getRemote(),
                 startsWith(expected.getRemote()));


### PR DESCRIPTION
This should address the issue with the code coverage, without needing to delete the generated scripts + binary until the end of the step when they are no longer needed.

If a the workspace is `//some/path/workspace`, now the files will be copied into `//some/path/workspace@tmp/matlab-uuid`. Currently they are copied into `//some/path/workspace/.matlab/tempDir-uuid`.

Removed the integration tests checking for a `.matlab` folder because checking that the temp directory is created properly and in the right place is already covered by the unit tests and is implementation detail rathern than part of the interface that we need to remain invariant.