### PR TITLE
Fixed issue 338

### DIFF
--- a/src/main/java/com/mathworks/ci/BuildArtifactAction.java
+++ b/src/main/java/com/mathworks/ci/BuildArtifactAction.java
@@ -45,6 +45,7 @@ public class BuildArtifactAction implements Action {
     public String getActionID(){
         return this.actionID;
     }
+
     @CheckForNull
     @Override
     public String getIconFileName() {
@@ -66,7 +67,8 @@ public class BuildArtifactAction implements Action {
     public List<BuildArtifactData> getBuildArtifact() throws ParseException, InterruptedException, IOException {
         List<BuildArtifactData> artifactData = new ArrayList<BuildArtifactData>();
 
-        FilePath fl = new FilePath(new File(build.getRootDir().getAbsolutePath() + "/" + BUILD_ARTIFACT_FILE + this.actionID +".json"));
+        FilePath fl = new FilePath(new File(build.getRootDir().getAbsolutePath() + "/" +
+                BUILD_ARTIFACT_FILE + this.actionID + ".json"));
         try (InputStreamReader reader = new InputStreamReader(new FileInputStream(new File(fl.toURI())), "UTF-8")) {
             Object obj = new JSONParser().parse(reader);
             JSONObject jo = (JSONObject) obj;

--- a/src/main/java/com/mathworks/ci/BuildArtifactAction.java
+++ b/src/main/java/com/mathworks/ci/BuildArtifactAction.java
@@ -24,11 +24,13 @@ public class BuildArtifactAction implements Action {
     private int totalCount;
     private int skipCount;
     private int failCount;
+    private String actionID;
     private static final String ROOT_ELEMENT = "taskDetails";
-    private static final String BUILD_ARTIFACT_FILE = "buildArtifact.json";
+    private static final String BUILD_ARTIFACT_FILE = "buildArtifact";
 
-    public BuildArtifactAction(Run<?, ?> build) {
+    public BuildArtifactAction(Run<?, ?> build, String actionID) {
         this.build = build;
+        this.actionID = actionID;
 
         // Setting the counts of task when Action is created.
         try{
@@ -40,6 +42,9 @@ public class BuildArtifactAction implements Action {
         }
     }
 
+    public String getActionID(){
+        return this.actionID;
+    }
     @CheckForNull
     @Override
     public String getIconFileName() {
@@ -55,12 +60,12 @@ public class BuildArtifactAction implements Action {
     @CheckForNull
     @Override
     public String getUrlName() {
-        return "buildresults";
+        return "buildresults" + this.actionID ;
     }
 
     public List<BuildArtifactData> getBuildArtifact() throws ParseException, InterruptedException, IOException {
         List<BuildArtifactData> artifactData = new ArrayList<BuildArtifactData>();
-        FilePath fl = new FilePath(new File(build.getRootDir().getAbsolutePath() + "/" + BUILD_ARTIFACT_FILE));
+        FilePath fl = new FilePath(new File(build.getRootDir().getAbsolutePath() + "/" + BUILD_ARTIFACT_FILE + this.actionID +".json"));
         try (InputStreamReader reader = new InputStreamReader(new FileInputStream(new File(fl.toURI())), "UTF-8")) {
             Object obj = new JSONParser().parse(reader);
             JSONObject jo = (JSONObject) obj;
@@ -131,7 +136,7 @@ public class BuildArtifactAction implements Action {
 
     private void setCounts() throws InterruptedException, ParseException {
         List<BuildArtifactData> artifactData = new ArrayList<BuildArtifactData>();
-        FilePath fl = new FilePath(new File(build.getRootDir(), BUILD_ARTIFACT_FILE));
+        FilePath fl = new FilePath(new File(build.getRootDir(), BUILD_ARTIFACT_FILE + this.actionID + ".json"));
         try (InputStreamReader reader = new InputStreamReader(new FileInputStream(new File(fl.toURI())), "UTF-8")) {
             Object obj = new JSONParser().parse(reader);
             JSONObject jo = (JSONObject) obj;

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
@@ -5,21 +5,17 @@ package com.mathworks.ci.actions;
  *
  */
 
-import com.mathworks.ci.Utilities;
-import com.sun.javafx.scene.control.skin.Utils;
 import java.io.File;
 import java.io.IOException;
 
 import hudson.FilePath;
 import hudson.model.Run;
-import hudson.console.LineTransformationOutputStream;
 
 import com.mathworks.ci.BuildArtifactAction;
 import com.mathworks.ci.BuildConsoleAnnotator;
 import com.mathworks.ci.MatlabExecutionException;
 import com.mathworks.ci.parameters.BuildActionParameters;
 import com.mathworks.ci.utilities.MatlabCommandRunner;
-import java.util.UUID;
 import org.apache.commons.lang.RandomStringUtils;
 
 public class RunMatlabBuildAction {
@@ -110,7 +106,7 @@ public class RunMatlabBuildAction {
                     FilePath rootLocation = new FilePath(
                             new File(
                                 build.getRootDir().getAbsolutePath(),
-                                "buildArtifact.json")
+                                "buildArtifact" + this.getActionID() + ".json")
                             );
                     jsonFile.copyTo(rootLocation);
                     jsonFile.delete();

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
@@ -35,12 +35,9 @@ public class RunMatlabBuildAction {
         return this.actionID;
     }
 
-    private void setActionID(){
-        this.actionID = RandomStringUtils.randomAlphanumeric(8);
-    }
-
     public RunMatlabBuildAction(MatlabCommandRunner runner, BuildConsoleAnnotator annotator, BuildActionParameters params) {
         this.runner = runner;
+        this.actionID = RandomStringUtils.randomAlphanumeric(8);
         this.annotator = annotator;
         this.params = params;
     }
@@ -54,8 +51,6 @@ public class RunMatlabBuildAction {
     }
 
     public void run() throws IOException, InterruptedException, MatlabExecutionException {
-        // set unique action ID for each build task
-        this.setActionID();
         // Copy plugins and override default plugins function
         runner.copyFileToTempFolder(DEFAULT_PLUGIN, DEFAULT_PLUGIN);
         runner.copyFileToTempFolder(BUILD_REPORT_PLUGIN, BUILD_REPORT_PLUGIN);

--- a/src/main/resources/+ciplugins/+jenkins/TaskRunProgressPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/TaskRunProgressPlugin.m
@@ -6,7 +6,7 @@ classdef TaskRunProgressPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
     methods (Access=protected)
 
         function runTask(plugin, pluginData)
-            disp("[MATLAB-Build-" + pluginData.TaskResults.Name + "]");
+            disp("[MATLAB-Build-" + pluginData.TaskResults.Name + "-" + getenv('MW_BUILD_PLUGIN_ACTION_ID') +"]");
             runTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
         end
     end

--- a/src/main/resources/com/mathworks/ci/BuildArtifactAction/index.jelly
+++ b/src/main/resources/com/mathworks/ci/BuildArtifactAction/index.jelly
@@ -59,12 +59,12 @@
                 <j:forEach var="p" items="${it.buildArtifact}" varStatus="status">
                     <tr>
                         <td class="pane" align="left">
-                            <a href="../console#matlab-${p.taskName}">${p.taskName}</a>
+                            <a href="../console#matlab-${p.taskName}-${it.actionID}">${p.taskName}</a>
                         </td>
                         <td class="pane" style="width:9em">
                             <span class="${pst.cssClass}">
                                 <j:if test="${p.taskFailed != false}">
-                                    <a href="../console#matlab-${p.taskName}"><font color="#EF2929"> FAILED </font> </a>
+                                    <a href="../console#matlab-${p.taskName}-${it.actionID}"><font color="#EF2929"> FAILED </font> </a>
                                 </j:if>
                                 <j:if test="${p.taskFailed == false}">
                                     <j:if test="${p.taskSkipped == false}">

--- a/src/main/resources/com/mathworks/ci/BuildArtifactAction/summary.jelly
+++ b/src/main/resources/com/mathworks/ci/BuildArtifactAction/summary.jelly
@@ -6,7 +6,7 @@
   xmlns:f="/lib/form"
   xmlns:i="jelly:fmt">
   <t:summary icon="document.png">
-    <p><a href="buildresults">MATLAB Build Results</a></p>
+    <p><a href="buildresults${it.actionID}">MATLAB Build Results</a></p>
     <span class="${pst.cssClass}">
       <j:if test="${it.totalCount == 0}">
         <font color="#EF2929"><h5>Unable to generate a build artifact. </h5></font>

--- a/src/test/java/integ/com/mathworks/ci/BuildArtifactActionTest.java
+++ b/src/test/java/integ/com/mathworks/ci/BuildArtifactActionTest.java
@@ -78,7 +78,7 @@ public class BuildArtifactActionTest {
         copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json",targetFile,artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
         int expectedSize = ba.size();
-        Assert.assertEquals("The build names are not matching",3,expectedSize);
+        Assert.assertEquals("Incorrect build artifact",3,expectedSize);
     }
 
     /**

--- a/src/test/java/integ/com/mathworks/ci/BuildArtifactActionTest.java
+++ b/src/test/java/integ/com/mathworks/ci/BuildArtifactActionTest.java
@@ -71,9 +71,11 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyBuildArtifactsReturned() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
+        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json",targetFile,artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
         int expectedSize = ba.size();
         Assert.assertEquals("The build names are not matching",3,expectedSize);
@@ -87,9 +89,11 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyFailedCount() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
+        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json",targetFile,artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
         boolean expectedStatus = ba.get(0).getTaskFailed();
         Assert.assertEquals("The task is passed",false,expectedStatus);
@@ -103,9 +107,11 @@ public class BuildArtifactActionTest {
     @Test
     public void verifySkipCount() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
+        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json",targetFile,artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
         Assert.assertEquals("The task is not skipped",true,ba.get(0).getTaskSkipped());
     }
@@ -118,9 +124,11 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyDurationIsAccurate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
+        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json",targetFile,artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
         Assert.assertEquals("The task duration is not matching","00:02:53",ba.get(0).getTaskDuration());
     }
@@ -133,9 +141,11 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyTaskDescriptionIsAccurate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
+        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json",targetFile,artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
         Assert.assertEquals("The task description is not matching","Test show",ba.get(0).getTaskDescription());
     }
@@ -148,9 +158,11 @@ public class BuildArtifactActionTest {
     @Test
     public void verifyTaskNameIsAccurate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
+        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json",targetFile,artifactRoot);
         List<BuildArtifactData> ba = ac.getBuildArtifact();
         Assert.assertEquals("The task name is not matching","show",ba.get(0).getTaskName());
     }
@@ -164,8 +176,10 @@ public class BuildArtifactActionTest {
     public void verifyTotalTaskCountIsAccurate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json","buildArtifact.json",artifactRoot);
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        copyFileInWorkspace("buildArtifacts.t2/buildArtifact.json",targetFile,artifactRoot);
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         Assert.assertEquals("Total task count is not correct",1,ac.getTotalCount());
     }
 
@@ -178,8 +192,10 @@ public class BuildArtifactActionTest {
     public void verifyTotalTaskCountIsAccurate2() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json",targetFile,artifactRoot);
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         Assert.assertEquals("Total task count is not correct",3,ac.getTotalCount());
     }
 
@@ -192,8 +208,10 @@ public class BuildArtifactActionTest {
     public void verifyTotalFailedTaskCountIsAccurate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json",targetFile,artifactRoot);
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         Assert.assertEquals("Total task count is not correct",3,ac.getTotalCount());
         Assert.assertEquals("Total task failed count is not correct",1,ac.getFailCount());
     }
@@ -206,10 +224,28 @@ public class BuildArtifactActionTest {
     public void verifyTotalSkipTaskCountIsAccurate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
         FilePath artifactRoot = new FilePath(build.getRootDir());
-        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json","buildArtifact.json",artifactRoot);
-        BuildArtifactAction ac = new BuildArtifactAction(build);
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json",targetFile,artifactRoot);
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
         Assert.assertEquals("Total task count is not correct",3,ac.getTotalCount());
         Assert.assertEquals("Total task skip count is not correct",1,ac.getSkipCount());
+    }
+
+    /**
+     *  Verify if ActionID is set correctly.
+     *
+     */
+
+    @Test
+    public void verifyActionIDisAppropriate() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
+        FreeStyleBuild build = getFreestyleBuild();
+        FilePath artifactRoot = new FilePath(build.getRootDir());
+        final String actionID = "abc123";
+        final String targetFile = "buildArtifact"+ actionID + ".json";
+        copyFileInWorkspace("buildArtifacts/t1/buildArtifact.json",targetFile,artifactRoot);
+        BuildArtifactAction ac = new BuildArtifactAction(build, actionID);
+        Assert.assertEquals("Incorrect ActionID",actionID,ac.getActionID());
     }
 
 

--- a/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
+++ b/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
@@ -166,7 +166,7 @@ public class RunMatlabBuildActionTest {
         // Should have deleted original file
         assertFalse(json.exists());
         // Should have copied file to root dir
-        assertTrue(new File(tmp, "buildArtifact.json").exists());
+        assertTrue(new File(tmp, "buildArtifact"+ action.getActionID() + ".json").exists());
     }
 
     @Test

--- a/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
+++ b/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
@@ -157,7 +157,7 @@ public class RunMatlabBuildActionTest {
         // Should have deleted original file
         assertFalse(json.exists());
         // Should have copied file to root dir
-        assertTrue(new File(tmp, "buildArtifact"+ action.getActionID() + ".json").exists());
+        assertTrue(new File(dest, "buildArtifact"+ action.getActionID() + ".json").exists());
     }
 
     @Test


### PR DESCRIPTION
This PR Closes #338 
#### Changes include 
* Added `actionID` to identify each build task separately.
* Under Jenkins root folder now files are getting store with `actionID` postfixed to it eg `buildArtifact<actionID>.jason` 
* `TaskRunProgressPlugin.m` now attaches `actionID` to the each task to avoid conflicting links.

#### Screenshots 
![image](https://github.com/mathworks/jenkins-matlab-plugin/assets/47204011/302a675b-0313-41f8-82d1-491dd759464a)

***
![image](https://github.com/mathworks/jenkins-matlab-plugin/assets/47204011/7370d140-3574-4652-9c3b-322d0d7e21fc)

***
![image](https://github.com/mathworks/jenkins-matlab-plugin/assets/47204011/7b5054ee-e88c-44b9-a8cf-16315ab60fd4)

***
![image](https://github.com/mathworks/jenkins-matlab-plugin/assets/47204011/d0cd73f5-70d3-4545-8463-40351871f864)

***

**Note: There are a few open questions here about the summary page where we can see multiple summaries as shown below. Please let me know your thoughts on the same if we need to continue as shown below. combining the summary has some UI 
limitations from Jenkins side.**  

![image](https://github.com/mathworks/jenkins-matlab-plugin/assets/47204011/a6fccfd3-7c6a-4dec-8ed6-f9ace3f28d0a)

* **We are adding `actionID` in the logf sentinals to avoid conflicting hyperlinks in case both build runs the same tasks. Should we support this ? per me its very rare that under same job somebody would run the same tasks.** 


![image](https://github.com/mathworks/jenkins-matlab-plugin/assets/47204011/f807220f-5d31-4873-b8df-2653eb638026)

