### PR TITLE
Added check for command textbox

### DIFF
--- a/src/main/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilder.java
+++ b/src/main/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilder.java
@@ -7,10 +7,13 @@ package com.mathworks.ci.freestyle;
  * 
  */
 
+import hudson.util.FormValidation;
 import java.io.IOException;
 import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -33,6 +36,7 @@ import com.mathworks.ci.parameters.RunActionParameters;
 import com.mathworks.ci.actions.MatlabActionFactory;
 import com.mathworks.ci.actions.RunMatlabCommandAction;
 import com.mathworks.ci.freestyle.options.StartupOptions;
+import org.kohsuke.stapler.verb.POST;
 
 public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep {
     // Deprecated
@@ -109,6 +113,14 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep 
         public boolean isApplicable(
                 @SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobtype) {
             return true;
+        }
+        @POST
+        public FormValidation doCheckMatlabCommand(@QueryParameter String matlabCommand) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            if (matlabCommand.isEmpty()) {
+                return FormValidation.error(Message.getValue("matlab.empty.command.error"));
+            }
+            return FormValidation.ok();
         }
     }
 

--- a/src/main/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilder.java
+++ b/src/main/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilder.java
@@ -116,9 +116,9 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep 
         }
 
         @POST
-        public FormValidation doCheckMatlabCommand(@QueryParameter String matlabCommand) {
+        public FormValidation doCheckMatlabCommand(@QueryParameter String value) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            if (matlabCommand.isEmpty()) {
+            if (value.isEmpty()) {
                 return FormValidation.error(Message.getValue("matlab.empty.command.error"));
             }
             return FormValidation.ok();

--- a/src/main/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilder.java
+++ b/src/main/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilder.java
@@ -114,6 +114,7 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep 
                 @SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobtype) {
             return true;
         }
+
         @POST
         public FormValidation doCheckMatlabCommand(@QueryParameter String matlabCommand) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     
 	  <f:entry title="Command" field="matlabCommand">
-	        <f:textbox/>
+	        <f:textbox checkMethod="post"/>
 	  </f:entry> 
 
       <f:optionalProperty field="startupOptions" title="Startup options" />

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -16,6 +16,7 @@ Releaseinfo.matlab.version.not.found.error = Error finding MATLAB release for gi
 matlab.not.found.error = Unable to launch MATLAB from the specified location. Verify the path to MATLAB root folder.
 matlab.not.found.error.for.node = Unable to launch MATLAB '%s' on the node '%s'. Verify global tool configuration for the specified node.
 matlab.execution.exception.prefix = Received a nonzero exit code %d while trying to run MATLAB.
+matlab.empty.command.error = Specify at least one script, function, or statement to execute.
 Builder.matlab.modelcoverage.support.warning = To generate a Cobertura model coverage report, use MATLAB R2018b or a newer release.
 Builder.matlab.exportstmresults.support.warning = To export Simulink Test Manager results, use MATLAB R2019a or a newer release.
 Builder.matlab.runner.script.target.file.linux.name = run_matlab_command.sh

--- a/src/test/java/integ/com/mathworks/ci/RunMatlabCommandBuilderTest.java
+++ b/src/test/java/integ/com/mathworks/ci/RunMatlabCommandBuilderTest.java
@@ -7,6 +7,9 @@ package com.mathworks.ci;
  * 
  */
 
+import com.gargoylesoftware.htmlunit.WebAssert;
+import com.gargoylesoftware.htmlunit.html.HtmlCheckBoxInput;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -377,4 +380,34 @@ public class RunMatlabCommandBuilderTest {
         jenkins.assertLogContains("Generating MATLAB script with content", build);
         jenkins.assertLogContains(expectedCommand, build);
     }
+
+    /*
+     * Test to verify error message when command is empty.
+     */
+
+    @Test
+    public void verifyErrorMessageOnEmptyCommand() throws Exception {
+        this.buildWrapper.setMatlabBuildWrapperContent(new MatlabBuildWrapperContent(Message.getValue("matlab.custom.location"), getMatlabroot("R2017a")));
+        project.getBuildWrappersList().add(this.buildWrapper);
+        project.getBuildersList().add(this.scriptBuilder);
+        HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
+
+        WebAssert.assertTextPresent(page,"Specify at least one script, function, or statement to execute.");
+    }
+
+    /*
+     * Test to verify no error message when command is provided.
+     */
+
+    @Test
+    public void verifyWhenCommandNonEmpty() throws Exception {
+        this.buildWrapper.setMatlabBuildWrapperContent(new MatlabBuildWrapperContent(Message.getValue("matlab.custom.location"), getMatlabroot("R2017a")));
+        project.getBuildWrappersList().add(this.buildWrapper);
+        this.scriptBuilder.setMatlabCommand("NONEMPTY");
+        project.getBuildersList().add(this.scriptBuilder);
+        HtmlPage page = jenkins.createWebClient().goTo("job/test0/configure");
+
+        WebAssert.assertTextNotPresent(page,"Specify at least one script, function, or statement to execute.");
+    }
+
 }


### PR DESCRIPTION
Fixed geck # 2221893 

* `Command` text box under `Run MATLAB Command` now checks if the the command box is empty 
* Empty command box shows an error message 

![image](https://github.com/user-attachments/assets/38de37ba-cdec-4b10-9ca4-dd6d51d6a988)

* Added Integ tests 