### PR TITLE
Add build results support in Run Command step and skipped task logs link in table

### DIFF
--- a/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/MatlabBuilderConstants.java
@@ -32,6 +32,11 @@ public class MatlabBuilderConstants {
     
     //Temporary MATLAB folder name in workspace 
     public static final String TEMP_MATLAB_FOLDER_NAME = ".matlab";
+
+    // MATLAB default function/plugin paths
+    public static final String DEFAULT_PLUGIN = "+ciplugins/+jenkins/getDefaultPlugins.m";
+    public static final String BUILD_REPORT_PLUGIN = "+ciplugins/+jenkins/BuildReportPlugin.m";
+    public static final String TASK_RUN_PROGRESS_PLUGIN = "+ciplugins/+jenkins/TaskRunProgressPlugin.m";
     
     public static final String NEW_LINE = System.getProperty("line.separator");
 

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import hudson.FilePath;
 import hudson.model.Run;
 
+import com.mathworks.ci.MatlabBuilderConstants;
 import com.mathworks.ci.BuildArtifactAction;
 import com.mathworks.ci.BuildConsoleAnnotator;
 import com.mathworks.ci.MatlabExecutionException;
@@ -22,13 +23,6 @@ public class RunMatlabBuildAction {
     private BuildActionParameters params; 
     private MatlabCommandRunner runner;
     private BuildConsoleAnnotator annotator;
-
-    private static String DEFAULT_PLUGIN = 
-        "+ciplugins/+jenkins/getDefaultPlugins.m";
-    private static String BUILD_REPORT_PLUGIN = 
-        "+ciplugins/+jenkins/BuildReportPlugin.m";
-    private static String TASK_RUN_PROGRESS_PLUGIN = 
-        "+ciplugins/+jenkins/TaskRunProgressPlugin.m";
     private String actionID;
 
     public String getActionID(){
@@ -52,9 +46,9 @@ public class RunMatlabBuildAction {
 
     public void run() throws IOException, InterruptedException, MatlabExecutionException {
         // Copy plugins and override default plugins function
-        runner.copyFileToTempFolder(DEFAULT_PLUGIN, DEFAULT_PLUGIN);
-        runner.copyFileToTempFolder(BUILD_REPORT_PLUGIN, BUILD_REPORT_PLUGIN);
-        runner.copyFileToTempFolder(TASK_RUN_PROGRESS_PLUGIN, TASK_RUN_PROGRESS_PLUGIN);
+        runner.copyFileToTempFolder(MatlabBuilderConstants.DEFAULT_PLUGIN, MatlabBuilderConstants.DEFAULT_PLUGIN);
+        runner.copyFileToTempFolder(MatlabBuilderConstants.BUILD_REPORT_PLUGIN, MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
+        runner.copyFileToTempFolder(MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN, MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN);
 
         
         // Set environment variable
@@ -119,6 +113,5 @@ public class RunMatlabBuildAction {
                 }
             }
         }
-
     }
 }

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabCommandAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabCommandAction.java
@@ -1,5 +1,7 @@
 package com.mathworks.ci.actions;
 
+import java.io.File;
+
 /**
  * Copyright 2024, The MathWorks Inc.
  *
@@ -7,37 +9,100 @@ package com.mathworks.ci.actions;
 
 import java.io.IOException;
 
+import org.apache.commons.lang.RandomStringUtils;
+
+import com.mathworks.ci.BuildArtifactAction;
+import com.mathworks.ci.BuildConsoleAnnotator;
+import com.mathworks.ci.MatlabBuilderConstants;
 import com.mathworks.ci.MatlabExecutionException;
 import com.mathworks.ci.parameters.RunActionParameters;
 import com.mathworks.ci.utilities.MatlabCommandRunner;
 
+import hudson.FilePath;
+import hudson.model.Run;
+
 public class RunMatlabCommandAction {
     private RunActionParameters params; 
     private MatlabCommandRunner runner;
+    private BuildConsoleAnnotator annotator;
+    private String actionID;
 
-    public RunMatlabCommandAction(MatlabCommandRunner runner, RunActionParameters params) {
+    public String getActionID(){
+        return this.actionID;
+    }
+
+    public RunMatlabCommandAction(MatlabCommandRunner runner, BuildConsoleAnnotator annotator, RunActionParameters params) {
         this.runner = runner;
+        this.actionID = RandomStringUtils.randomAlphanumeric(8);
+        this.annotator = annotator;
         this.params = params;
     }
 
     public RunMatlabCommandAction(RunActionParameters params) throws IOException, InterruptedException {
-        this(new MatlabCommandRunner(params), params);
+        this(new MatlabCommandRunner(params), 
+                new BuildConsoleAnnotator(
+                    params.getTaskListener().getLogger(), 
+                    params.getBuild().getCharset()),
+                params);
     }
 
     public void run() throws IOException, InterruptedException, MatlabExecutionException {
+        // Copy plugins and override default plugins function
+        runner.copyFileToTempFolder(MatlabBuilderConstants.DEFAULT_PLUGIN, MatlabBuilderConstants.DEFAULT_PLUGIN);
+        runner.copyFileToTempFolder(MatlabBuilderConstants.BUILD_REPORT_PLUGIN, MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
+        runner.copyFileToTempFolder(MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN, MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN);
+
+        
+        // Set environment variable
+        runner.addEnvironmentVariable(
+                "MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE",
+                "ciplugins.jenkins.getDefaultPlugins");
+        runner.addEnvironmentVariable("MW_BUILD_PLUGIN_ACTION_ID",this.getActionID());
+        runner.addEnvironmentVariable(
+                "MW_MATLAB_TEMP_FOLDER",
+                runner.getTempFolder().toString());
+
+        // Redirect output to the build annotator
+        runner.redirectStdOut(annotator);
+
+        // Prepare MATLAB command
+        String command = "addpath('" 
+            + runner.getTempFolder().getRemote()
+            + "');" + this.params.getCommand();
+
         try {
-            runner.runMatlabCommand(this.params.getCommand());
+            runner.runMatlabCommand(command);
         } catch (Exception e) {
             this.params.getTaskListener().getLogger()
                 .println(e.getMessage());
             throw(e);
         } finally {
+            annotator.forceEol();
+
             try {
-                this.runner.removeTempFolder();
+                // Handle build result
+                Run<?,?> build = this.params.getBuild();
+                FilePath jsonFile = new FilePath(runner.getTempFolder(), "buildArtifact.json");
+                if (jsonFile.exists()) {
+                    FilePath rootLocation = new FilePath(
+                            new File(
+                                build.getRootDir().getAbsolutePath(),
+                                "buildArtifact" + this.getActionID() + ".json")
+                            );
+                    jsonFile.copyTo(rootLocation);
+                    jsonFile.delete();
+                    build.addAction(new BuildArtifactAction(build, this.getActionID()));
+                }
             } catch (Exception e) {
                 // Don't want to override more important error
                 // thrown in catch block
                 System.err.println(e.toString());
+            } finally {
+                try {
+                    this.runner.removeTempFolder();
+                } catch (Exception e) {
+                    System.err.println(e.toString());
+                }
             }
         }
     }

--- a/src/main/resources/+ciplugins/+jenkins/TaskRunProgressPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/TaskRunProgressPlugin.m
@@ -9,5 +9,10 @@ classdef TaskRunProgressPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
             disp("[MATLAB-Build-" + pluginData.TaskResults.Name + "-" + getenv('MW_BUILD_PLUGIN_ACTION_ID') +"]");
             runTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
         end
+
+        function skipTask(plugin, pluginData)
+            disp("[MATLAB-Build-" + pluginData.TaskResults.Name + "-" + getenv('MW_BUILD_PLUGIN_ACTION_ID') +"]");
+            skipTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
+        end
     end
  end

--- a/src/main/resources/com/mathworks/ci/BuildArtifactAction/index.jelly
+++ b/src/main/resources/com/mathworks/ci/BuildArtifactAction/index.jelly
@@ -82,7 +82,12 @@
                                     </j:if>
                                 </j:if>
                                 <j:if test="${p.taskSkipped == true}">
-                                    <font color="#FCE94F"> SKIPPED </font>
+                                    <j:if test="${it.actionID != ''}">
+                                       <a href="../console#matlab-${p.taskName}-${it.actionID}"><font color="#FCE94F"> SKIPPED </font> </a>
+                                   </j:if>
+                                   <j:if test="${it.actionID == ''}">
+                                       <a href="../console#matlab-${p.taskName}"><font color="#FCE94F"> SKIPPED </font> </a>
+                                   </j:if>
                                 </j:if>
                             </span>
                         </td>

--- a/src/main/resources/com/mathworks/ci/BuildArtifactAction/summary.jelly
+++ b/src/main/resources/com/mathworks/ci/BuildArtifactAction/summary.jelly
@@ -12,12 +12,15 @@
         <font color="#EF2929"><h5>Unable to generate a build artifact. </h5></font>
       </j:if>
     </span>
-    <p><b>Tasks run: <font color="Blue">${it.totalCount}</font></b></p>
-    <br>
-    <b>Failed: <font color="red">${it.failCount}</font></b>
-    </br>
-    <br>
-    <b>Skipped: <font color="orange">${it.skipCount}</font></b>
-    </br>
+    <p>
+      <b>Tasks run: <font color="Blue">${it.totalCount}</font></b>
+      <br></br>
+      <br>
+      <b>Failed: <font color="red">${it.failCount}</font></b>
+      </br>
+      <br>
+      <b>Skipped: <font color="orange">${it.skipCount}</font></b>
+      </br>
+    </p>
   </t:summary>
 </j:jelly>

--- a/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
+++ b/src/test/java/unit/com/mathworks/ci/actions/RunMatlabBuildActionTest.java
@@ -18,6 +18,9 @@ import static org.junit.Assert.*;
 import org.mockito.Mock;
 import org.mockito.InOrder;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import hudson.FilePath;
@@ -26,7 +29,9 @@ import hudson.model.TaskListener;
 
 import com.mathworks.ci.BuildArtifactAction;
 import com.mathworks.ci.BuildConsoleAnnotator;
+import com.mathworks.ci.MatlabBuilderConstants;
 import com.mathworks.ci.MatlabExecutionException;
+import com.mathworks.ci.actions.RunMatlabBuildAction;
 import com.mathworks.ci.utilities.MatlabCommandRunner;
 import com.mathworks.ci.parameters.BuildActionParameters;
 
@@ -65,21 +70,21 @@ public class RunMatlabBuildActionTest {
     public void shouldCopyPluginsToTempDirectory() throws IOException, InterruptedException, MatlabExecutionException {
         action.run();
 
-        String DEFAULT_PLUGIN = 
-            "+ciplugins/+jenkins/getDefaultPlugins.m";
-        String BUILD_REPORT_PLUGIN = 
-            "+ciplugins/+jenkins/BuildReportPlugin.m";
-        String TASK_RUN_PROGRESS_PLUGIN = 
-            "+ciplugins/+jenkins/TaskRunProgressPlugin.m";
+        // String DEFAULT_PLUGIN = 
+        //     "+ciplugins/+jenkins/getDefaultPlugins.m";
+        // String BUILD_REPORT_PLUGIN = 
+        //     "+ciplugins/+jenkins/BuildReportPlugin.m";
+        // String TASK_RUN_PROGRESS_PLUGIN = 
+        //     "+ciplugins/+jenkins/TaskRunProgressPlugin.m";
 
         InOrder inOrder = inOrder(runner);
 
         inOrder.verify(runner)
-            .copyFileToTempFolder(DEFAULT_PLUGIN, DEFAULT_PLUGIN);
+            .copyFileToTempFolder(MatlabBuilderConstants.DEFAULT_PLUGIN, MatlabBuilderConstants.DEFAULT_PLUGIN);
         inOrder.verify(runner)
-            .copyFileToTempFolder(BUILD_REPORT_PLUGIN, BUILD_REPORT_PLUGIN);
+            .copyFileToTempFolder(MatlabBuilderConstants.BUILD_REPORT_PLUGIN, MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
         inOrder.verify(runner)
-            .copyFileToTempFolder(TASK_RUN_PROGRESS_PLUGIN, TASK_RUN_PROGRESS_PLUGIN);
+            .copyFileToTempFolder(MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN, MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN);
     }
 
     @Test

--- a/src/test/java/unit/com/mathworks/ci/actions/RunMatlabCommandActionTest.java
+++ b/src/test/java/unit/com/mathworks/ci/actions/RunMatlabCommandActionTest.java
@@ -1,5 +1,7 @@
 package com.mathworks.ci.actions;
 
+import java.io.File;
+
 /**
  * Copyright 2024, The MathWorks Inc.
  *
@@ -7,28 +9,43 @@ package com.mathworks.ci.actions;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
 
 import org.junit.Test;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
+import hudson.FilePath;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 
+import com.mathworks.ci.MatlabBuilderConstants;
+import com.mathworks.ci.BuildArtifactAction;
+import com.mathworks.ci.BuildConsoleAnnotator;
 import com.mathworks.ci.MatlabExecutionException;
+import com.mathworks.ci.actions.RunMatlabCommandAction;
 import com.mathworks.ci.utilities.MatlabCommandRunner;
 import com.mathworks.ci.parameters.RunActionParameters;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class RunMatlabCommandActionTest {
     @Mock RunActionParameters params;
+    @Mock BuildConsoleAnnotator annotator;
     @Mock MatlabCommandRunner runner;
     @Mock PrintStream out;
     @Mock TaskListener listener;
+    @Mock Run build;
+
+    @Mock FilePath tempFolder;
 
     private boolean setup = false;
     private RunMatlabCommandAction action;
@@ -38,8 +55,46 @@ public class RunMatlabCommandActionTest {
     public void init() {
         if (!setup) {
             setup = true;
-            action = new RunMatlabCommandAction(runner, params);
+            action = new RunMatlabCommandAction(runner, annotator, params);
+
+            when(runner.getTempFolder()).thenReturn(tempFolder);
+            when(tempFolder.getRemote()).thenReturn("/path/less/traveled");
+
+            when(params.getTaskListener()).thenReturn(listener);
+            when(listener.getLogger()).thenReturn(out);
+
+            when(params.getBuild()).thenReturn(build);
         }
+    }
+
+    @Test
+    public void shouldCopyPluginsToTempDirectory() throws IOException, InterruptedException, MatlabExecutionException {
+        action.run();
+
+        InOrder inOrder = inOrder(runner);
+
+        inOrder.verify(runner)
+            .copyFileToTempFolder(MatlabBuilderConstants.DEFAULT_PLUGIN, MatlabBuilderConstants.DEFAULT_PLUGIN);
+        inOrder.verify(runner)
+            .copyFileToTempFolder(MatlabBuilderConstants.BUILD_REPORT_PLUGIN, MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
+        inOrder.verify(runner)
+            .copyFileToTempFolder(MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN, MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN);
+    }
+
+    @Test
+    public void shouldOverrideDefaultPlugins() throws IOException, InterruptedException, MatlabExecutionException {
+        action.run();
+
+        verify(runner).addEnvironmentVariable(
+                "MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE",
+                "ciplugins.jenkins.getDefaultPlugins");
+    }
+
+    @Test
+    public void shouldUseCustomAnnotator() throws IOException, InterruptedException, MatlabExecutionException {
+        action.run();
+
+        verify(runner).redirectStdOut(annotator);
     }
 
     @Test
@@ -48,7 +103,7 @@ public class RunMatlabCommandActionTest {
 
         action.run();
 
-        verify(runner).runMatlabCommand("Sit!");
+        verify(runner).runMatlabCommand("addpath('/path/less/traveled'); Sit!");
     }
 
     @Test
@@ -65,6 +120,35 @@ public class RunMatlabCommandActionTest {
             verify(out).println(e.getMessage());
             assertEquals(12, e.getExitCode());
         };
+    }
+
+    @Test
+    public void shouldNotAddActionIfNoBuildResult() throws IOException, InterruptedException, MatlabExecutionException {
+        action.run();
+
+        verify(build, never()).addAction(any(BuildArtifactAction.class));
+    }
+
+    @Test
+    public void shouldCopyBuildResultsToRootAndAddAction() throws IOException, InterruptedException, MatlabExecutionException {
+        File tmp = Files.createTempDirectory("temp").toFile();
+        tmp.deleteOnExit();
+        
+        File dest = Files.createTempDirectory("dest").toFile();
+        dest.deleteOnExit();
+
+        File json = new File(tmp, "buildArtifact.json");
+        json.createNewFile();
+
+        doReturn(new FilePath(tmp)).when(runner).getTempFolder();
+        doReturn(dest).when(build).getRootDir();
+
+        action.run();
+
+        // Should have deleted original file
+        assertFalse(json.exists());
+        // Should have copied file to root dir
+        assertTrue(new File(dest, "buildArtifact"+ action.getActionID() + ".json").exists());
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/mathworks/jenkins-matlab-plugin/issues/285, https://github.com/mathworks/jenkins-matlab-plugin/issues/337 and https://github.com/mathworks/jenkins-matlab-plugin/issues/349 by:

- Adding sentinel for skipped tasks in logs and linking table links to them
- Adding build results table generation for Run MATLAB command step
