### PR TITLE
Fix matlab batch path bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<artifactId>matlab</artifactId>
-	<version>2.15.1-SNAPSHOT</version>
+	<version>2.16.0-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 	<name>MATLAB Plugin</name>

--- a/src/main/java/com/mathworks/ci/MatlabInstallation.java
+++ b/src/main/java/com/mathworks/ci/MatlabInstallation.java
@@ -64,13 +64,7 @@ public class MatlabInstallation extends ToolInstallation
         if (home == null) {
             return;
         }
-        FilePath matlabHome = new FilePath(new File(home));
-        FilePath matlabBin = new FilePath(matlabHome, "bin");
-        env.put("PATH+matlabroot", matlabBin.getRemote());
-        FilePath matlabBatchFolder = matlabHome.getParent();
-        if (matlabBatchFolder != null) {
-            env.put("PATH+matlabbatch", matlabBatchFolder.getRemote());
-        }
+        env.put("PATH+matlabroot", home + "/bin");
     }
 
     public static MatlabInstallation[] getAll() {

--- a/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
+++ b/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
@@ -201,11 +201,6 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
         if (matlabBinDir == null) {
             throw new MatlabNotFoundError(Message.getValue("matlab.not.found.error"));
         }
-        // Add matlab-batch executable in path
-        FilePath batchExecutable = getNthParentFilePath(matlabExecutablePath, 3);
-        if (batchExecutable != null && batchExecutable.exists()) {
-            context.env("PATH+matlabbatch", batchExecutable.getRemote());
-        }
 
         // Add "matlabroot" without bin as env variable which will be available across
         // the build.

--- a/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
+++ b/src/main/java/com/mathworks/ci/UseMatlabVersionBuildWrapper.java
@@ -216,19 +216,4 @@ public class UseMatlabVersionBuildWrapper extends SimpleBuildWrapper {
         return (launcher.isUnix()) ? "/bin/matlab" : "\\bin\\matlab.exe";
     }
 
-    public static FilePath getNthParentFilePath(FilePath path, int levels) {
-        if (path == null || levels < 0) {
-            return null;
-        }
-
-        FilePath currentPath = path;
-        for (int i = 0; i < levels; i++) {
-            if (currentPath == null) {
-                return null;
-            }
-            currentPath = currentPath.getParent();
-        }
-        return currentPath;
-    }
-
 }

--- a/src/main/java/com/mathworks/ci/Utilities.java
+++ b/src/main/java/com/mathworks/ci/Utilities.java
@@ -40,24 +40,14 @@ public class Utilities {
             return;
         }
 
-        FilePath matlabRoot = getNodeSpecificHome(name,
-                cmp.getNode(), listener, env);
+        FilePath matlabRoot = getNodeSpecificHome(name, cmp.getNode(), listener, env);
 
-        FilePath toolHome = matlabRoot.getParent();
-        if (toolHome == null) {
-            return;
-        }
-        if (matlabRoot != null && toolHome.exists()) {
-            env.put("PATH+matlabbatch", toolHome.getRemote());
-        }
-
-        String matlabExecutablePath = getNodeSpecificHome(name,
-                cmp.getNode(), listener, env).getRemote() + ((Boolean.TRUE.equals(cmp.isUnix())) ? "/bin" : "\\bin");
-        env.put("PATH+matlabroot", matlabExecutablePath);
+        FilePath matlabBin = new FilePath(matlabRoot, "bin");
+        env.put("PATH+matlabroot", matlabBin.getRemote());
 
         // Specify which MATLAB was added to path.
         listener.getLogger().println(
-                "\n" + String.format(Message.getValue("matlab.added.to.path.from"), matlabExecutablePath) + "\n");
+                "\n" + String.format(Message.getValue("matlab.added.to.path.from"), matlabBin.getRemote()) + "\n");
     }
 
     public static FilePath getNodeSpecificHome(String instName, Node node, TaskListener listener, EnvVars env)

--- a/src/main/java/com/mathworks/ci/tools/MatlabInstaller.java
+++ b/src/main/java/com/mathworks/ci/tools/MatlabInstaller.java
@@ -96,7 +96,8 @@ public class MatlabInstaller extends ToolInstaller {
         mpmInstall(mpm, this.getRelease(), this.getProducts(), matlabRoot, node, log);
 
         // Copy downloaded matlab-batch to tool directory
-        matlabBatch.copyTo(new FilePath(toolRoot, "matlab-batch" + extension));
+        FilePath matlabBin = new FilePath(matlabRoot, "bin");
+        matlabBatch.copyTo(new FilePath(matlabBin, "matlab-batch" + extension));
 
         // Delete temp directory
         tempDir.deleteRecursive();


### PR DESCRIPTION
This change puts `matlab-batch` in `$MATLAB_ROOT/bin` directory and adding that to path. The reason for this is because in our current `MatlabInstallation` code there is no info about the node or node channel being run. If we use FilePath as I before, there is a problem where it will use Windows style paths on Linux nodes if the server is hosted on Windows.

It is also a bit strange that we add `$MATLAB_ROOT/..` (installation home) to path even for MATLAB installations that were not configured by Install Automatically. This could add unintended folders to path for self-managed MATLAB installations.