### PR TITLE
Fix help text for release

### DIFF
--- a/src/main/resources/com/mathworks/ci/tools/MatlabInstaller/help-release.html
+++ b/src/main/resources/com/mathworks/ci/tools/MatlabInstaller/help-release.html
@@ -14,9 +14,4 @@
     <strong>Example:</strong> latest <br>
     <strong>Example:</strong> R2023bU4 <br>
   </p>
-  <p>
-    <strong>Note:</strong>  The plugin does not install dependencies on a Linux platform. If you are using a Linux platform,
-    verify that the required software is available before installing products using MATLAB Package Manager. For more information, see
-    <a href="https://in.mathworks.com/help/install/ug/get-mpm-os-command-line.html">Get MATLAB Package Manager.</a>
-  </p>
 </div>


### PR DESCRIPTION
Addressing comments for https://github.com/mathworks/jenkins-matlab-plugin/issues/394

It was decided that the Release help text was not the correct place to discuss this limitation, but it will handled in the doc.