### PR TITLE
Update release format for install automatically

### DIFF
--- a/src/main/java/com/mathworks/ci/tools/MatlabInstaller.java
+++ b/src/main/java/com/mathworks/ci/tools/MatlabInstaller.java
@@ -170,6 +170,10 @@ public class MatlabInstaller extends ToolInstaller {
             }
         }
 
+        if (name.startsWith("r")) {
+            name = name.replaceFirst("r", "R");
+        }
+
         return new MatlabRelease(name, isPrerelease);
     }
 


### PR DESCRIPTION
Change Automatic Installation name to use capital R in version name (ex: R2024b instead of r2024b).